### PR TITLE
[CHORE] jacoco를 이용한 코드 커버리지 적용.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,0 @@
-## PR Description 🗒️
-
-## 추가/변경 사항 및 설명 📝
-
-## To Reviewers 🙏 // 중점적 봐줬으면 하는 부분.
-
-## Issue close ✂️

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## PR Description 🗒️
+
+## 추가/변경 사항 및 설명 📝
+
+## To Reviewers 🙏 // 중점적 봐줬으면 하는 부분.
+
+## Issue close ✂️

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ tasks.named('asciidoctor') {
 }
 
 jacocoTestReport {
-	reports { // 내가 원하는 형태로 출력함.
+	reports {
 		html.enabled(true)
 	}
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'org.springframework.boot' version '2.7.8'
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 	id 'org.asciidoctor.jvm.convert' version '3.2.0'
+	id 'jacoco'
 }
 
 group = 'com.prgrms'
@@ -58,9 +59,39 @@ dependencyManagement {
 tasks.named('test') {
 	outputs.dir snippetsDir
 	useJUnitPlatform()
+
+	finalizedBy('jacocoTestReport')
 }
 
 tasks.named('asciidoctor') {
 	inputs.dir snippetsDir
 	dependsOn test
+}
+
+jacocoTestReport {
+	reports { // 내가 원하는 형태로 출력함.
+		html.enabled(true)
+	}
+
+	finalizedBy('jacocoTestCoverageVerification')
+}
+
+jacocoTestCoverageVerification {
+	violationRules {
+		rule {
+			enabled = false
+			element = 'CLASS'
+
+			limit {
+				counter = 'BRANCH'
+				value = 'COVEREDRATIO'
+				minimum = 0.5
+			}
+			limit {
+				counter = 'LINE'
+				value = 'COVEREDRATIO'
+				minimum = 0.5
+			}
+		}
+	}
 }

--- a/src/main/lombok.config
+++ b/src/main/lombok.config
@@ -1,0 +1,2 @@
+config.stopBubbling = true
+lombok.addLombokGeneratedAnnotation = true


### PR DESCRIPTION
- build.gradle 파일에 task 추가. -> 초기 라인 커버리지, 브랜치 커버리지 0퍼로 설정. (추후 50퍼로 변경 예정)
  - 코드 커버리지 50퍼로 설정 이유 : 테스트를 짜는 이유가 커버리지를 채우기 위함이 되어서는 안된다고 생각. -> 좋은 부정 지표로써의 사용을 위함. 
- 코드 커버리지에서 lombok 어노테이션 제거를 위한 설정 파일 추가.