### PR TITLE
[FIX] checkstyle 관련 오류

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ checkstyle {
     maxWarnings = 0 // 규칙이 어긋나는 코드가 하나라도 있을 경우 빌드 fail을 내고 싶다면 이 선언을 추가한다.
     configFile = file("${rootProject.projectDir}/config/checkstyle/naver-checkstyle-rules.xml")
     configProperties = ["suppressionFile": "${rootProject.projectDir}/config/checkstyle/naver-checkstyle-suppressions.xml"]
-    toolVersion = "8.24"  // checkstyle 버전 8.24 이상 선언
+    toolVersion = "10.7.0"  // checkstyle
 }
 
 dependencyManagement {


### PR DESCRIPTION
- chekstyle의 버전을 최신 버전으로 변경

## PR Description 🗒️

## 추가/변경 사항 및 설명 📝
`gradlew checkstyleMain --stacktrace` 결과 checkstyle의 버전이 낮아 record를 읽지 못하는 문제였음(java 17 지원 x)

```
Caused by: G:\IdeaProjects\Team-06-Final-BE\src\main\java\com\example\demo\common\ApiResponse.java:7:8: unexpected token: record
	at com.puppycrawl.tools.checkstyle.grammar.GeneratedJavaRecognizer.typeDefinitionInternal(GeneratedJavaRecognizer.java:584)
	at com.puppycrawl.tools.checkstyle.grammar.GeneratedJavaRecognizer.typeDefinition(GeneratedJavaRecognizer.java:389)
	... 47 more
```
![image](https://user-images.githubusercontent.com/28258648/220153936-b8790044-60a9-438c-afc9-2e5aaf3babaf.png)

checkstyle 버전 업을 통해 해결 

## To Reviewers 🙏

## Issue close ✂️
close #45 
