### PR TITLE
[FEAT] 플라이웨이 적용, test db docker compose 작성, 환경별 application.yml 분리

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: make secret envfiles for prod
+        run: |
+          echo "${{secrets.PROD_DB_ENV}}" > ./prod_db_info.env
+
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+
+**.env

--- a/localTestDB/conf.d/my.cnf
+++ b/localTestDB/conf.d/my.cnf
@@ -1,0 +1,10 @@
+[client]
+default-character-set = utf8mb4
+
+[mysql]
+default-character-set = utf8mb4
+
+[mysqld]
+character-set-client-handshake = FALSE
+character-set-server           = utf8mb4
+collation-server               = utf8mb4_unicode_ci

--- a/localTestDB/docker-compose.yml
+++ b/localTestDB/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+services:
+  hype-testDB:
+    image: mysql:8.0
+    ports:
+      - 3306:3306
+    volumes:
+      - ./conf.d:/etc/mysql/conf.d
+
+    env_file: db_info.env
+    environment:
+      TZ: Asia/Seoul
+    restart: always
+

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -17,4 +17,4 @@ else
 fi
 
 echo "> $JAR_PATH 배포"
-nohup java -jar /home/ubuntu/build/build/libs/pearls-1.0.jar > /dev/null 2> /dev/null < /dev/null &
+nohup java -jar -Dspring.profiles.active=dev /home/ubuntu/build/build/libs/pearls-1.0.jar > /dev/null 2> /dev/null < /dev/null &

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,23 @@
+spring:
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+
+  config:
+    import: optional:file:localTestDB/db_info.env[.properties]
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/${MYSQL_DATABASE}
+    username: ${MYSQL_USER}
+    password: ${MYSQL_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    database: mysql
+
+

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,23 @@
+spring:
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+
+  config:
+    import: optional:file:prod_db_info.env[.properties]
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://${MYSQL_HOST}/${MYSQL_DATABASE}
+    username: ${MYSQL_USER}
+    password: ${MYSQL_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    database: mysql
+
+

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,15 @@
+spring:
+  flyway:
+    enabled: false
+  h2:
+    console:
+      enabled: true
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb;MODE=MYSQL
+    username: sa
+    password:
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create-drop

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,23 +1,4 @@
 spring:
-  flyway:
-    enabled: true
-    baseline-on-migrate: true
-
-  config:
-    import: optional:file:localTestDB/db_info.env[.properties]
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/${MYSQL_DATABASE}
-    username: ${MYSQL_USER}
-    password: ${MYSQL_PASSWORD}
-  jpa:
-    hibernate:
-      ddl-auto: validate
-    properties:
-      hibernate:
-        format_sql: true
-        show_sql: true
-    database-platform: org.hibernate.dialect.MySQL8Dialect
-    database: mysql
-
-
+  profiles:
+    active:
+      - local

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,13 +1,23 @@
 spring:
-  h2:
-    console:
-      enabled: true
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+
+  config:
+    import: optional:file:localTestDB/db_info.env[.properties]
   datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:testdb
-    username: sa
-    password:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/${MYSQL_DATABASE}
+    username: ${MYSQL_USER}
+    password: ${MYSQL_PASSWORD}
   jpa:
-    show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    database: mysql
+
+

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,113 @@
+create table battle
+(
+    id                     bigint not null auto_increment,
+    created_at             TIMESTAMP,
+    updated_at             TIMESTAMP,
+    challenged_vote_count  integer,
+    challenging_vote_count integer,
+    challenged_post_id     bigint,
+    challenging_post_id    bigint,
+    member_id              bigint,
+    primary key (id)
+) engine=InnoDB;
+
+create table likes
+(
+    id         bigint not null auto_increment,
+    created_at TIMESTAMP,
+    updated_at TIMESTAMP,
+    member_id  bigint,
+    post_id    bigint,
+    primary key (id)
+) engine=InnoDB;
+
+create table member
+(
+    id                        bigint  not null auto_increment,
+    created_at                TIMESTAMP,
+    updated_at                TIMESTAMP,
+    count_of_challenge_ticket integer not null,
+    ranking                   integer not null,
+    victory_count             integer not null,
+    victory_point             integer not null,
+    nickname                  varchar(24),
+    profile_image_url         varchar(2000),
+    refresh_token             varchar(255),
+    social_id                 varchar(255),
+    social_type               varchar(255),
+    primary key (id)
+) engine=InnoDB;
+
+create table post
+(
+    id                 bigint  not null auto_increment,
+    created_at         TIMESTAMP,
+    updated_at         TIMESTAMP,
+    content            longtext,
+    is_possible_battle bit     not null,
+    like_count         integer not null,
+    album_cover_url    varchar(255),
+    genre              varchar(255),
+    music_id           varchar(255),
+    music_url          varchar(255),
+    singer             varchar(255),
+    title              varchar(255),
+    member_id          bigint,
+    primary key (id)
+) engine=InnoDB;
+
+create table vote
+(
+    id         bigint not null auto_increment,
+    created_at TIMESTAMP,
+    updated_at TIMESTAMP,
+    battle_id  bigint,
+    post_id    bigint,
+    member_id  bigint,
+    primary key (id)
+) engine=InnoDB;
+
+alter table battle
+    add constraint FK44g0dk93ew8jm94i8imquwps2
+        foreign key (challenged_post_id)
+            references post (id);
+
+alter table battle
+    add constraint FKrs5thx0uawi7bs9y66d2wwf4f
+        foreign key (challenging_post_id)
+            references post (id);
+
+alter table battle
+    add constraint FKfhohk3campcgr4i0738qr95n7
+        foreign key (member_id)
+            references member (id);
+
+alter table likes
+    add constraint FKa4vkf1skcfu5r6o5gfb5jf295
+        foreign key (member_id)
+            references member (id);
+
+alter table likes
+    add constraint FKowd6f4s7x9f3w50pvlo6x3b41
+        foreign key (post_id)
+            references post (id);
+
+alter table post
+    add constraint FK83s99f4kx8oiqm3ro0sasmpww
+        foreign key (member_id)
+            references member (id);
+
+alter table vote
+    add constraint FKm1nxvydnsl77b26t5kpbl3c1c
+        foreign key (battle_id)
+            references battle (id);
+
+alter table vote
+    add constraint FKl3c067ewaw5xktl5cjvniv3e9
+        foreign key (post_id)
+            references post (id);
+
+alter table vote
+    add constraint FKgkbgl6xp2rpgwghb7mtyuv48h
+        foreign key (member_id)
+            references member (id);


### PR DESCRIPTION
## PR Description 🗒️
- [x] 플라이웨이 적용
- [x] test db docker compose 파일 작성
- [x] 환경별 application yml 분리
- [x] RDS 연결 <- prod application.yml 작성 및 cd workflow, deploy.sh 수정 하긴 했는데 제대로 될지 잘 모르겠음
## 추가/변경 사항 및 설명 📝
- application.yml 의 profile을 로컬환경에서의 local, test환경에서의 test, 배포 환경에서의 prod(아직 못만듦)로 분리
- db 형상관리 툴인 플라이웨이 적용
  - V1_init.sql 부터 시작해서, Entity의 변경사항이 있을때마다 그 변경사항에 대한 sql 문을 새로 작성해 버전을 같이 올려주면서 관리 해야함
## To Reviewers 🙏
localTestDB에 db_info.env 파일이 아래와 같은 형식으로 존재해야 합니다.
```
MYSQL_DATABASE= 
MYSQL_USER=
MYSQL_PASSWORD=
MYSQL_ROOT_PASSWORD=
```
괜찮다면, 일시적으로 pr에 cd를 걸어놔도 괜찮을까요??

## Issue close ✂️