### PR TITLE
[FEAT] 음악 공유 게시글 전체 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/demo/common/ResponseMessage.java
+++ b/src/main/java/com/example/demo/common/ResponseMessage.java
@@ -5,7 +5,8 @@ import lombok.Getter;
 @Getter
 public enum ResponseMessage {
 	// Post
-	SUCCESS_CREATE_POST("음악 공유 게시글 등록 성공");
+	SUCCESS_CREATE_POST("음악 공유 게시글 등록 성공"),
+	SUCCESS_FIND_ALL_POST("음악 공유 게시글 리스트 조회 성공");
 
 	final String message;
 

--- a/src/main/java/com/example/demo/controller/PostController.java
+++ b/src/main/java/com/example/demo/controller/PostController.java
@@ -3,15 +3,19 @@ package com.example.demo.controller;
 import java.net.URI;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import com.example.demo.common.ApiResponse;
 import com.example.demo.common.ResponseMessage;
 import com.example.demo.dto.post.PostCreateRequestDto;
+import com.example.demo.dto.post.PostsFindResponseDto;
+import com.example.demo.model.post.Genre;
 import com.example.demo.service.PostService;
 
 import lombok.RequiredArgsConstructor;
@@ -35,6 +39,15 @@ public class PostController {
 		ApiResponse apiResponse = ApiResponse.success(ResponseMessage.SUCCESS_CREATE_POST.getMessage());
 
 		return ResponseEntity.created(location).body(apiResponse);
+	}
+
+	@GetMapping
+	public ResponseEntity<ApiResponse> findAllPosts(@RequestParam(name = "genre", required = false) Genre genre,
+		@RequestParam(name = "possible", required = false) Boolean possible) {
+		PostsFindResponseDto posts = postService.findAllPosts(genre, possible);
+
+		ApiResponse apiResponse = ApiResponse.success(ResponseMessage.SUCCESS_FIND_ALL_POST.getMessage(), posts);
+		return ResponseEntity.ok(apiResponse);
 	}
 
 }

--- a/src/main/java/com/example/demo/dto/post/PostFindMusicResponseDto.java
+++ b/src/main/java/com/example/demo/dto/post/PostFindMusicResponseDto.java
@@ -1,0 +1,25 @@
+package com.example.demo.dto.post;
+
+import com.example.demo.model.post.Genre;
+import com.example.demo.model.post.Music;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import reactor.util.annotation.NonNull;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record PostFindMusicResponseDto(
+	@NonNull String musicName,
+	@NonNull String albumCoverUrl,
+	@NonNull String singer,
+	@NonNull Genre genre
+) {
+	public static PostFindMusicResponseDto from(Music music) {
+		return PostFindMusicResponseDto.builder()
+			.musicName(music.getTitle())
+			.albumCoverUrl(music.getAlbumCoverUrl())
+			.singer(music.getSinger())
+			.genre(music.getGenre())
+			.build();
+	}
+}

--- a/src/main/java/com/example/demo/dto/post/PostFindResponseDto.java
+++ b/src/main/java/com/example/demo/dto/post/PostFindResponseDto.java
@@ -1,0 +1,26 @@
+package com.example.demo.dto.post;
+
+import com.example.demo.model.post.Post;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import reactor.util.annotation.NonNull;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record PostFindResponseDto(
+	@NonNull Long postId,
+	@NonNull PostFindMusicResponseDto music,
+	int likeCount,
+	boolean isBattlePossible,
+	String nickname
+) {
+	public static PostFindResponseDto from(Post post) {
+		return PostFindResponseDto.builder()
+			.postId(post.getId())
+			.music(PostFindMusicResponseDto.from(post.getMusic()))
+			.likeCount(post.getLikeCount())
+			.isBattlePossible(post.isPossibleBattle())
+			.nickname(post.getMember().getNickname())
+			.build();
+	}
+}

--- a/src/main/java/com/example/demo/dto/post/PostFindResponseDto.java
+++ b/src/main/java/com/example/demo/dto/post/PostFindResponseDto.java
@@ -23,4 +23,14 @@ public record PostFindResponseDto(
 			.nickname(post.getMember().getNickname())
 			.build();
 	}
+
+	public static PostFindResponseDto testFrom(Post post) {
+		return PostFindResponseDto.builder()
+			.postId(0L)
+			.music(PostFindMusicResponseDto.from(post.getMusic()))
+			.likeCount(post.getLikeCount())
+			.isBattlePossible(post.isPossibleBattle())
+			.nickname(post.getMember().getNickname())
+			.build();
+	}
 }

--- a/src/main/java/com/example/demo/dto/post/PostsFindResponseDto.java
+++ b/src/main/java/com/example/demo/dto/post/PostsFindResponseDto.java
@@ -1,0 +1,17 @@
+package com.example.demo.dto.post;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record PostsFindResponseDto(
+	List<PostFindResponseDto> posts
+) {
+	public static PostsFindResponseDto from(List<PostFindResponseDto> posts) {
+		return PostsFindResponseDto.builder()
+			.posts(posts)
+			.build();
+	}
+}

--- a/src/main/java/com/example/demo/model/post/Genre.java
+++ b/src/main/java/com/example/demo/model/post/Genre.java
@@ -4,7 +4,8 @@ import lombok.Getter;
 
 @Getter
 public enum Genre {
-	DANCE("댄스");
+	DANCE("댄스"),
+	POP("팝");
 
 	final String name;
 

--- a/src/main/java/com/example/demo/model/post/Music.java
+++ b/src/main/java/com/example/demo/model/post/Music.java
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-class Music {
+public class Music {
 
 	@NotBlank
 	private String musicId;

--- a/src/main/java/com/example/demo/repository/PostRepository.java
+++ b/src/main/java/com/example/demo/repository/PostRepository.java
@@ -1,8 +1,18 @@
 package com.example.demo.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.example.demo.model.post.Genre;
 import com.example.demo.model.post.Post;
 
+@Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
+	List<Post> findByMusic_GenreAndIsPossibleBattle(Genre genre, boolean isPossibleBattle);
+
+	List<Post> findByMusic_Genre(Genre genre);
+
+	List<Post> findByIsPossibleBattle(boolean isPossibleBattle);
 }

--- a/src/main/java/com/example/demo/service/PostService.java
+++ b/src/main/java/com/example/demo/service/PostService.java
@@ -1,11 +1,18 @@
 package com.example.demo.service;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.demo.dto.post.PostCreateRequestDto;
+import com.example.demo.dto.post.PostFindResponseDto;
+import com.example.demo.dto.post.PostsFindResponseDto;
 import com.example.demo.model.member.Member;
 import com.example.demo.model.member.Social;
+import com.example.demo.model.post.Genre;
 import com.example.demo.model.post.Post;
 import com.example.demo.repository.MemberRepository;
 import com.example.demo.repository.PostRepository;
@@ -32,4 +39,23 @@ public class PostService {
 
 		return post.getId();
 	}
+
+	public PostsFindResponseDto findAllPosts(Genre genre, Boolean possible) {
+		List<PostFindResponseDto> posts = new ArrayList<>();
+		if (Objects.nonNull(genre) && Objects.nonNull(possible)) {
+			postRepository.findByMusic_GenreAndIsPossibleBattle(genre, possible)
+				.forEach(post -> posts.add(PostFindResponseDto.from(post)));
+		} else if (Objects.nonNull(genre)) {
+			postRepository.findByMusic_Genre(genre)
+				.forEach(post -> posts.add(PostFindResponseDto.from(post)));
+		} else if (Objects.nonNull(possible)) {
+			postRepository.findByIsPossibleBattle(possible)
+				.forEach(post -> posts.add(PostFindResponseDto.from(post)));
+		} else {
+			postRepository.findAll()
+				.forEach(post -> posts.add(PostFindResponseDto.from(post)));
+		}
+		return PostsFindResponseDto.from(posts);
+	}
+
 }

--- a/src/test/java/com/example/demo/controller/PostControllerTest.java
+++ b/src/test/java/com/example/demo/controller/PostControllerTest.java
@@ -1,14 +1,19 @@
 package com.example.demo.controller;
 
+import static org.mockito.Mockito.*;
 import static org.springframework.http.MediaType.*;
 import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,13 +22,19 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 import com.example.demo.dto.post.PostCreateRequestDto;
+import com.example.demo.dto.post.PostFindResponseDto;
+import com.example.demo.dto.post.PostsFindResponseDto;
+import com.example.demo.model.member.Member;
+import com.example.demo.model.member.Social;
 import com.example.demo.model.post.Genre;
+import com.example.demo.model.post.Post;
 import com.example.demo.service.PostService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -54,7 +65,6 @@ class PostControllerTest {
 	private final String content = "comment";
 
 	@Test
-	@Async("webExecutor")
 	void 성공_음악_공유_게시글을_등록할_수_있다() throws Exception {
 		// given
 		PostCreateRequestDto postCreateRequestDto = PostCreateRequestDto.builder()
@@ -100,6 +110,90 @@ class PostControllerTest {
 					fieldWithPath("data").type(NULL).description("API 요청 응답 메시지 (null)")
 				)
 			));
+	}
+
+	@Test
+	void 성공_음악_공유_게시글을_장르와_대결가능여부_기준으로_조회할_수_있다() throws Exception {
+		// given
+		MultiValueMap<String, String> queries = new LinkedMultiValueMap<>();
+		queries.add("genre", Genre.POP.toString());
+		queries.add("possible", "true");
+
+		when(postService.findAllPosts(Genre.POP, true)).thenReturn(getPostsDto());
+
+		// when
+		ResultActions resultActions = mockMvc.perform(
+			get("/api/v1/posts")
+				.contentType(APPLICATION_JSON)
+				.params(queries)
+		);
+
+		// then
+		resultActions.andExpect(status().isOk())
+			.andDo(print())
+			.andDo(document("Find Post",
+				requestParameters(
+					parameterWithName("genre").description("필터링 할 장르 값 (null 가능)"),
+					parameterWithName("possible").description("대결 가능 여부 (null 가능)")
+				),
+				responseFields(
+					fieldWithPath("success").type(BOOLEAN).description("API 요청 성공 여부"),
+					fieldWithPath("message").type(STRING).description("API 요청 응답 메시지"),
+					fieldWithPath("data").type(OBJECT).description("API 요청 응답 메시지"),
+					fieldWithPath("data.posts[]").type(ARRAY).description("조회한 공유글 정보 리스트"),
+					fieldWithPath("data.posts[].postId").type(NUMBER).description("조회한 공유글 id"),
+					fieldWithPath("data.posts[].music").type(OBJECT).description("조회한 공유글 음악 정보"),
+					fieldWithPath("data.posts[].music.musicName").type(STRING).description("조회한 공유글 음악 제목"),
+					fieldWithPath("data.posts[].music.albumCoverUrl").type(STRING)
+						.description("조회한 공유글 음악 앨범 표지 이미지 url"),
+					fieldWithPath("data.posts[].music.singer").type(STRING).description("조회한 공유글 음악 가수명"),
+					fieldWithPath("data.posts[].music.genre").type(STRING).description("조회한 공유글 음악 장르"),
+					fieldWithPath("data.posts[].likeCount").type(NUMBER).description("조회한 공유글의 좋아요 수"),
+					fieldWithPath("data.posts[].isBattlePossible").type(BOOLEAN).description("조회한 공유글 대결 가능 여부"),
+					fieldWithPath("data.posts[].nickname").type(STRING).description("조회한 공유글 작성자 이름")
+				)
+			));
+	}
+
+	private Member createMember() {
+
+		return Member.builder()
+			.profileImageUrl("profile")
+			.nickname("name")
+			.countOfChallengeTicket(5)
+			.ranking(1)
+			.victoryPoint(10)
+			.victoryCount(10)
+			.refreshToken("token")
+			.socialType(Social.GOOGLE)
+			.socialId("socialId")
+			.build();
+	}
+
+	private List<Post> getPosts() {
+		List<Post> posts = new ArrayList<>();
+		for (int i = 0; i < 5; i++) {
+			Post post = Post.create(musicId, albumCoverUrl, singer, musicName, Genre.DANCE, musicUrl,
+				content, isPossibleBattle, createMember());
+			posts.add(post);
+		}
+		for (int i = 0; i < 5; i++) {
+			Post post = Post.create(musicId, albumCoverUrl, singer, musicName, Genre.POP, musicUrl,
+				content, isPossibleBattle, createMember());
+			posts.add(post);
+		}
+		for (int i = 0; i < 5; i++) {
+			Post post = Post.create(musicId, albumCoverUrl, singer, musicName, Genre.POP, musicUrl,
+				content, false, createMember());
+			posts.add(post);
+		}
+		return posts;
+	}
+
+	private PostsFindResponseDto getPostsDto() {
+		List<PostFindResponseDto> postDtoList = new ArrayList<>();
+		getPosts().forEach(post -> postDtoList.add(PostFindResponseDto.testFrom(post)));
+		return PostsFindResponseDto.from(postDtoList);
 	}
 
 }

--- a/src/test/java/com/example/demo/service/PostServiceTest.java
+++ b/src/test/java/com/example/demo/service/PostServiceTest.java
@@ -3,6 +3,9 @@ package com.example.demo.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -10,6 +13,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.example.demo.dto.post.PostCreateRequestDto;
+import com.example.demo.dto.post.PostFindResponseDto;
+import com.example.demo.dto.post.PostsFindResponseDto;
 import com.example.demo.model.member.Member;
 import com.example.demo.model.member.Social;
 import com.example.demo.model.post.Genre;
@@ -31,6 +36,7 @@ class PostServiceTest {
 	private final String musicName = "musicName";
 	private final String musicUrl = "musicUrl";
 	private final String albumCoverUrl = "albumCoverUrl";
+	private final String content = "recommend";
 	private final Genre genre = Genre.DANCE;
 	private final String singer = "hype";
 	private final boolean isPossibleBattle = true;
@@ -62,6 +68,73 @@ class PostServiceTest {
 		verify(postRepository).save(any());
 	}
 
+	@Test
+	void 성공_음악_공유_게시글을_모두_조회할_수_있다() {
+		// given
+		List<Post> testPosts = getPosts();
+		PostsFindResponseDto expected = getPostsDto(testPosts);
+
+		when(postRepository.findAll()).thenReturn(testPosts);
+
+		// when
+		PostsFindResponseDto posts = postService.findAllPosts(null, null);
+
+		// then
+		assertThat(posts).isEqualTo(expected);
+	}
+
+	@Test
+	void 성공_음악_공유_게시글을_장르_기준으로_조회할_수_있다() {
+		// given
+		List<Post> testPosts = getPosts().stream()
+			.filter(post -> post.getMusic().getGenre() == Genre.DANCE)
+			.toList();
+		PostsFindResponseDto expected = getPostsDto(testPosts);
+
+		when(postRepository.findByMusic_Genre(Genre.DANCE)).thenReturn(testPosts);
+
+		// when
+		PostsFindResponseDto posts = postService.findAllPosts(Genre.DANCE, null);
+
+		// then
+		assertThat(posts).isEqualTo(expected);
+	}
+
+	@Test
+	void 성공_음악_공유_게시글을_대결가능_기준으로_조회할_수_있다() {
+		// given
+		List<Post> testPosts = getPosts().stream()
+			.filter(Post::isPossibleBattle)
+			.toList();
+		PostsFindResponseDto expected = getPostsDto(testPosts);
+
+		when(postRepository.findByIsPossibleBattle(true)).thenReturn(testPosts);
+
+		// when
+		PostsFindResponseDto posts = postService.findAllPosts(null, true);
+
+		// then
+		assertThat(posts).isEqualTo(expected);
+	}
+
+	@Test
+	void 성공_음악_공유_게시글을_장르와_대결가능_기준으로_조회할_수_있다() {
+		// given
+		List<Post> testPosts = getPosts().stream()
+			.filter(post -> post.getMusic().getGenre() == Genre.POP && post.isPossibleBattle())
+			.toList();
+		PostsFindResponseDto expected = getPostsDto(testPosts);
+
+		when(postRepository.findByMusic_GenreAndIsPossibleBattle(Genre.POP, true))
+			.thenReturn(testPosts);
+
+		// when
+		PostsFindResponseDto posts = postService.findAllPosts(Genre.POP, true);
+
+		// then
+		assertThat(posts).isEqualTo(expected);
+	}
+
 	private Member createMember() {
 
 		return Member.builder()
@@ -77,4 +150,29 @@ class PostServiceTest {
 			.build();
 	}
 
+	private List<Post> getPosts() {
+		List<Post> posts = new ArrayList<>();
+		for (int i = 0; i < 5; i++) {
+			Post post = Post.create(musicId, albumCoverUrl, singer, musicName, Genre.DANCE, musicUrl,
+				content, isPossibleBattle, createMember());
+			posts.add(post);
+		}
+		for (int i = 0; i < 5; i++) {
+			Post post = Post.create(musicId, albumCoverUrl, singer, musicName, Genre.POP, musicUrl,
+				content, isPossibleBattle, createMember());
+			posts.add(post);
+		}
+		for (int i = 0; i < 5; i++) {
+			Post post = Post.create(musicId, albumCoverUrl, singer, musicName, Genre.POP, musicUrl,
+				content, false, createMember());
+			posts.add(post);
+		}
+		return posts;
+	}
+
+	private PostsFindResponseDto getPostsDto(List<Post> posts) {
+		List<PostFindResponseDto> postDtoList = new ArrayList<>();
+		posts.forEach(post -> postDtoList.add(PostFindResponseDto.from(post)));
+		return PostsFindResponseDto.from(postDtoList);
+	}
 }


### PR DESCRIPTION
## PR Description 🗒️
음악 공유 게시글 전체 조회 기능 구현 (장르 및 배틀 가능 여부 필터링 추가)

## 추가/변경 사항 및 설명 📝
`Music` : 응답 데이터 변환 과정에서 Music 클래스가 필요하여 접근 제어자 `public` 으로 변경
그 외 파일: 게시글 전체 조회 기능 구현

## To Reviewers 🙏
34번 브랜치에서 파생된 것을 기억하고자 미리 PR 올려뒀습니다. (현재 코드리뷰는 하지 않아도 됩니다.)
다른 기능이 좀 더 구체화 되었을 때 그에 맞춰 수정 및 테스트 코드 작성하겠습니다.