### PR TITLE
[FEAT] 대결 상세 정보 리스트 조회(숏폼 리스트)

### DIFF
--- a/src/main/java/com/example/demo/common/ResponseMessage.java
+++ b/src/main/java/com/example/demo/common/ResponseMessage.java
@@ -8,7 +8,9 @@ public enum ResponseMessage {
 	SUCCESS_CREATE_POST("음악 공유 게시글 등록 성공"),
 	SUCCESS_FIND_ALL_POST("음악 공유 게시글 리스트 조회 성공"),
 	SUCCESS_FIND_POST("음악 공유 게시글 상세 조회 성공"),
-	SUCCESS_FIND_ALL_CANDIDATE_POST("대결곡 후보 게시글 리스트 조회 성공");
+	SUCCESS_FIND_ALL_CANDIDATE_POST("대결곡 후보 게시글 리스트 조회 성공"),
+
+	SUCCESS_FIND_ALL_BATTLE_DETAILS("대결 상세 정보 리스트 조회 성공");
 
 	final String message;
 

--- a/src/main/java/com/example/demo/controller/BattleController.java
+++ b/src/main/java/com/example/demo/controller/BattleController.java
@@ -9,7 +9,6 @@ import com.example.demo.common.ApiResponse;
 import com.example.demo.dto.battle.BattleDetailsListResponseDto;
 import com.example.demo.service.BattleService;
 import com.example.demo.service.PrincipalService;
-import com.example.demo.service.VoteService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -20,7 +19,6 @@ public class BattleController {
 
 	private final PrincipalService principalService;
 	private final BattleService battleService;
-	private final VoteService voteService;
 
 	@GetMapping
 	public ResponseEntity<ApiResponse> getBattleDetailsList() {

--- a/src/main/java/com/example/demo/controller/BattleController.java
+++ b/src/main/java/com/example/demo/controller/BattleController.java
@@ -1,0 +1,35 @@
+package com.example.demo.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.demo.common.ApiResponse;
+import com.example.demo.dto.battle.BattleDetailsListResponseDto;
+import com.example.demo.service.BattleService;
+import com.example.demo.service.PrincipalService;
+import com.example.demo.service.VoteService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/battles")
+public class BattleController {
+
+	private final PrincipalService principalService;
+	private final BattleService battleService;
+	private final VoteService voteService;
+
+	@GetMapping
+	public ResponseEntity<ApiResponse> getBattleDetailsList() {
+		BattleDetailsListResponseDto responseDto = battleService.getBattleDetailsListInProgress();
+		return ResponseEntity.ok(
+			ApiResponse.success(
+				"대결 상세 정보 리스트 조회 성공",
+				responseDto
+			)
+		);
+	}
+}

--- a/src/main/java/com/example/demo/controller/BattleController.java
+++ b/src/main/java/com/example/demo/controller/BattleController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.demo.common.ApiResponse;
+import com.example.demo.common.ResponseMessage;
 import com.example.demo.dto.battle.BattleDetailsListResponseDto;
 import com.example.demo.service.BattleService;
 import com.example.demo.service.PrincipalService;
@@ -25,7 +26,7 @@ public class BattleController {
 		BattleDetailsListResponseDto responseDto = battleService.getBattleDetailsListInProgress();
 		return ResponseEntity.ok(
 			ApiResponse.success(
-				"대결 상세 정보 리스트 조회 성공",
+				ResponseMessage.SUCCESS_FIND_ALL_BATTLE_DETAILS.getMessage(),
 				responseDto
 			)
 		);

--- a/src/main/java/com/example/demo/dto/battle/BattleDetailsListResponseDto.java
+++ b/src/main/java/com/example/demo/dto/battle/BattleDetailsListResponseDto.java
@@ -1,0 +1,17 @@
+package com.example.demo.dto.battle;
+
+import java.util.List;
+
+import com.example.demo.model.battle.Battle;
+
+public record BattleDetailsListResponseDto(
+	List<BattleDetailsResponseDto> battles
+) {
+	public static BattleDetailsListResponseDto of(List<Battle> battles) {
+		return new BattleDetailsListResponseDto(
+			battles.stream()
+				.map(BattleDetailsResponseDto::of)
+				.toList()
+		);
+	}
+}

--- a/src/main/java/com/example/demo/dto/battle/BattleDetailsResponseDto.java
+++ b/src/main/java/com/example/demo/dto/battle/BattleDetailsResponseDto.java
@@ -9,16 +9,16 @@ import lombok.Builder;
 public record BattleDetailsResponseDto(
 	Long battleId,
 	GenreVoResponseDto battleGenre,
-	BattlePostResponseDto challenged,
-	BattlePostResponseDto challenging
+	BattlePostResponseVo challenged,
+	BattlePostResponseVo challenging
 ) {
 
 	public static BattleDetailsResponseDto of(Battle battle) {
 		return BattleDetailsResponseDto.builder()
 			.battleId(battle.getId())
 			.battleGenre(GenreVoResponseDto.of(battle.getGenre()))
-			.challenged(BattlePostResponseDto.of(battle.getChallengedPost().getPost()))
-			.challenging(BattlePostResponseDto.of(battle.getChallengingPost().getPost()))
+			.challenged(BattlePostResponseVo.of(battle.getChallengedPost().getPost()))
+			.challenging(BattlePostResponseVo.of(battle.getChallengingPost().getPost()))
 			.build();
 	}
 }

--- a/src/main/java/com/example/demo/dto/battle/BattleDetailsResponseDto.java
+++ b/src/main/java/com/example/demo/dto/battle/BattleDetailsResponseDto.java
@@ -1,0 +1,24 @@
+package com.example.demo.dto.battle;
+
+import com.example.demo.dto.genre.GenreVoResponseDto;
+import com.example.demo.model.battle.Battle;
+
+import lombok.Builder;
+
+@Builder
+public record BattleDetailsResponseDto(
+	Long battleId,
+	GenreVoResponseDto battleGenre,
+	BattlePostResponseDto challenged,
+	BattlePostResponseDto challenging
+) {
+
+	public static BattleDetailsResponseDto of(Battle battle) {
+		return BattleDetailsResponseDto.builder()
+			.battleId(battle.getId())
+			.battleGenre(GenreVoResponseDto.of(battle.getGenre()))
+			.challenged(BattlePostResponseDto.of(battle.getChallengedPost().getPost()))
+			.challenging(BattlePostResponseDto.of(battle.getChallengingPost().getPost()))
+			.build();
+	}
+}

--- a/src/main/java/com/example/demo/dto/battle/BattlePostResponseDto.java
+++ b/src/main/java/com/example/demo/dto/battle/BattlePostResponseDto.java
@@ -1,0 +1,16 @@
+package com.example.demo.dto.battle;
+
+import com.example.demo.dto.common.MusicVoResponseDto;
+import com.example.demo.model.post.Post;
+
+public record BattlePostResponseDto(
+	Long postId,
+	MusicVoResponseDto music
+) {
+	public static BattlePostResponseDto of(Post post) {
+		return new BattlePostResponseDto(
+			post.getId(),
+			MusicVoResponseDto.of(post.getMusic())
+		);
+	}
+}

--- a/src/main/java/com/example/demo/dto/battle/BattlePostResponseDto.java
+++ b/src/main/java/com/example/demo/dto/battle/BattlePostResponseDto.java
@@ -1,6 +1,6 @@
 package com.example.demo.dto.battle;
 
-import com.example.demo.dto.common.MusicVoResponseDto;
+import com.example.demo.dto.member.MusicVoResponseDto;
 import com.example.demo.model.post.Post;
 
 public record BattlePostResponseDto(

--- a/src/main/java/com/example/demo/dto/battle/BattlePostResponseVo.java
+++ b/src/main/java/com/example/demo/dto/battle/BattlePostResponseVo.java
@@ -3,12 +3,12 @@ package com.example.demo.dto.battle;
 import com.example.demo.dto.member.MusicVoResponseDto;
 import com.example.demo.model.post.Post;
 
-public record BattlePostResponseDto(
+public record BattlePostResponseVo(
 	Long postId,
 	MusicVoResponseDto music
 ) {
-	public static BattlePostResponseDto of(Post post) {
-		return new BattlePostResponseDto(
+	public static BattlePostResponseVo of(Post post) {
+		return new BattlePostResponseVo(
 			post.getId(),
 			MusicVoResponseDto.of(post.getMusic())
 		);

--- a/src/main/java/com/example/demo/repository/BattleRepository.java
+++ b/src/main/java/com/example/demo/repository/BattleRepository.java
@@ -13,5 +13,7 @@ import com.example.demo.model.battle.BattleStatus;
 public interface BattleRepository extends JpaRepository<Battle, Long> {
 	List<Battle> findByStatusAndCreatedAtIsBefore(BattleStatus status, LocalDateTime endDate);
 
+	List<Battle> findAllByStatusEquals(BattleStatus progressStatus);
+
 	List<Battle> findByStatusAndUpdatedAtBetween(BattleStatus status, LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/src/main/java/com/example/demo/service/BattleService.java
+++ b/src/main/java/com/example/demo/service/BattleService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.demo.dto.battle.BattleDetailsListResponseDto;
 import com.example.demo.model.battle.Battle;
 import com.example.demo.model.battle.BattleStatus;
 import com.example.demo.repository.BattleRepository;
@@ -39,4 +40,12 @@ public class BattleService {
 		LocalDateTime lastBattleDay = now.minusDays(perm - 1);
 		return battleRepository.findByStatusAndUpdatedAtBetween(BattleStatus.END, lastBattleDay, now);
 	}
+
+	public BattleDetailsListResponseDto getBattleDetailsListInProgress() {
+		List<Battle> battleListInProgress = battleRepository.findAllByStatusEquals(BattleStatus.PROGRESS);
+		return BattleDetailsListResponseDto.of(
+			battleListInProgress
+		);
+	}
 }
+

--- a/src/test/java/com/example/demo/controller/battle/BattleDetailsListIntegrationTest.java
+++ b/src/test/java/com/example/demo/controller/battle/BattleDetailsListIntegrationTest.java
@@ -1,0 +1,155 @@
+package com.example.demo.controller.battle;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.example.demo.common.ApiResponse;
+import com.example.demo.dto.battle.BattleDetailsListResponseDto;
+import com.example.demo.model.battle.Battle;
+import com.example.demo.model.battle.BattleStatus;
+import com.example.demo.model.member.Member;
+import com.example.demo.model.member.Social;
+import com.example.demo.model.post.Genre;
+import com.example.demo.model.post.Post;
+import com.example.demo.repository.BattleRepository;
+import com.example.demo.repository.MemberRepository;
+import com.example.demo.repository.PostRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class BattleDetailsListIntegrationTest {
+
+	private static final int PROGRESS_SIZE = 5;
+	private static final int ENDED_SIZE = 5;
+
+	@Autowired
+	private TestRestTemplate restTemplate;
+
+	@Autowired
+	private BattleRepository battleRepository;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private PostRepository postRepository;
+
+	@Autowired
+	@SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+	private ObjectMapper mapper = new ObjectMapper();
+
+	@BeforeEach
+	void setUp() {
+		clear();
+	}
+
+	private void clear() {
+		battleRepository.deleteAll();
+		postRepository.deleteAll();
+		memberRepository.deleteAll();
+	}
+
+	@Test
+	void 성공_진행중인_모든_배틀_정보를_조회할_수_있다() throws JsonProcessingException {
+		// given
+		List<Battle> battleListProgress = createProgressBattleList();
+		List<Battle> battleListEnd = createEndBattleList();
+		BattleDetailsListResponseDto expected = BattleDetailsListResponseDto.of(battleListProgress);
+
+		// when
+		ResponseEntity<ApiResponse> response = restTemplate.getForEntity("/api/v1/battles", ApiResponse.class);
+
+		// then
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody().success()).isTrue();
+		String actualJson = mapper.writeValueAsString(response.getBody().data());
+		BattleDetailsListResponseDto responseDto = mapper.readValue(actualJson, BattleDetailsListResponseDto.class);
+		assertThat(responseDto)
+			.usingRecursiveComparison()
+			.isEqualTo(expected);
+	}
+
+	private List<Battle> createProgressBattleList() {
+		List<Battle> battles = new ArrayList<>();
+		for (int i = 0; i < PROGRESS_SIZE; i++) {
+			Member member1 = createMember();
+			Member member2 = createMember();
+			Post post1 = createPost(String.format("ABCD123%s", i), member1);
+			Post post2 = createPost(String.format("ABCD124%s", i), member2);
+			Battle battle = createProgressBattle(post1, post2);
+			battles.add(battle);
+		}
+		return battles;
+	}
+
+	private List<Battle> createEndBattleList() {
+		List<Battle> battles = new ArrayList<>();
+		for (int i = 0; i < ENDED_SIZE; i++) {
+			Member member1 = createMember();
+			Member member2 = createMember();
+			Post post1 = createPost(String.format("ABCD125%s", i), member1);
+			Post post2 = createPost(String.format("ABCD126%s", i), member2);
+			Battle battle = createEndBattle(post1, post2);
+			battles.add(battle);
+		}
+		return battles;
+	}
+
+	private Battle createProgressBattle(Post post1, Post post2) {
+		Battle battle = new Battle(
+			post1.getMusic().getGenre(),
+			BattleStatus.PROGRESS,
+			post1,
+			post2);
+		battleRepository.save(battle);
+		return battle;
+	}
+
+	private Battle createEndBattle(Post post1, Post post2) {
+		Battle battle = new Battle(
+			post1.getMusic().getGenre(),
+			BattleStatus.END,
+			post1,
+			post2);
+		battleRepository.save(battle);
+		return battle;
+	}
+
+	private Post createPost(String musicId, Member member) {
+		Post post = Post.create(
+			musicId,
+			"albumCoverUrl",
+			"singer",
+			"title",
+			Genre.CLASSIC,
+			"musicUrl",
+			"content",
+			true,
+			member
+		);
+		postRepository.save(post);
+		return post;
+	}
+
+	private Member createMember() {
+		Member member = new Member(
+			"https://hype.music/images/1",
+			"nickname",
+			"refreshToken",
+			Social.GOOGLE,
+			"socialId");
+		memberRepository.save(member);
+		return member;
+	}
+}

--- a/src/test/java/com/example/demo/controller/battle/BattleDetailsListRestDocsTest.java
+++ b/src/test/java/com/example/demo/controller/battle/BattleDetailsListRestDocsTest.java
@@ -27,14 +27,13 @@ import com.example.demo.controller.BattleController;
 import com.example.demo.dto.battle.BattleDetailsListResponseDto;
 import com.example.demo.dto.battle.BattleDetailsResponseDto;
 import com.example.demo.dto.battle.BattlePostResponseDto;
-import com.example.demo.dto.common.MusicVoResponseDto;
 import com.example.demo.dto.genre.GenreVoResponseDto;
+import com.example.demo.dto.member.MusicVoResponseDto;
 import com.example.demo.model.post.Genre;
 import com.example.demo.model.post.Music;
 import com.example.demo.security.TokenAuthenticationFilter;
 import com.example.demo.service.BattleService;
 import com.example.demo.service.PrincipalService;
-import com.example.demo.service.VoteService;
 
 @WithMockUser
 @ExtendWith({MockitoExtension.class})
@@ -56,9 +55,6 @@ public class BattleDetailsListRestDocsTest {
 
 	@MockBean
 	private BattleService battleService;
-
-	@MockBean
-	private VoteService voteService;
 
 	@Test
 	void 성공_모든_진행중인_대결들의_상세정보_리스트를_조회할_수_있다() throws Exception {

--- a/src/test/java/com/example/demo/controller/battle/BattleDetailsListRestDocsTest.java
+++ b/src/test/java/com/example/demo/controller/battle/BattleDetailsListRestDocsTest.java
@@ -26,7 +26,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import com.example.demo.controller.BattleController;
 import com.example.demo.dto.battle.BattleDetailsListResponseDto;
 import com.example.demo.dto.battle.BattleDetailsResponseDto;
-import com.example.demo.dto.battle.BattlePostResponseDto;
+import com.example.demo.dto.battle.BattlePostResponseVo;
 import com.example.demo.dto.genre.GenreVoResponseDto;
 import com.example.demo.dto.member.MusicVoResponseDto;
 import com.example.demo.model.post.Genre;
@@ -138,10 +138,10 @@ public class BattleDetailsListRestDocsTest {
 	private BattleDetailsListResponseDto createResponseDto() {
 		return new BattleDetailsListResponseDto(
 			List.of(
-				new BattleDetailsResponseDto(
-					1L,
-					GenreVoResponseDto.of(Genre.CLASSIC),
-					new BattlePostResponseDto(
+				BattleDetailsResponseDto.builder()
+					.battleId(1L)
+					.battleGenre(GenreVoResponseDto.of(Genre.CLASSIC))
+					.challenged(new BattlePostResponseVo(
 						1L,
 						MusicVoResponseDto.of(
 							new Music(
@@ -153,8 +153,8 @@ public class BattleDetailsListRestDocsTest {
 								"musicUrl"
 							)
 						)
-					),
-					new BattlePostResponseDto(
+					))
+					.challenging(new BattlePostResponseVo(
 						2L,
 						MusicVoResponseDto.of(
 							new Music(
@@ -166,8 +166,8 @@ public class BattleDetailsListRestDocsTest {
 								"musicUrl2"
 							)
 						)
-					)
-				)
+					))
+					.build()
 			)
 		);
 	}

--- a/src/test/java/com/example/demo/controller/battle/BattleDetailsListRestDocsTest.java
+++ b/src/test/java/com/example/demo/controller/battle/BattleDetailsListRestDocsTest.java
@@ -1,0 +1,178 @@
+package com.example.demo.controller.battle;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.example.demo.controller.BattleController;
+import com.example.demo.dto.battle.BattleDetailsListResponseDto;
+import com.example.demo.dto.battle.BattleDetailsResponseDto;
+import com.example.demo.dto.battle.BattlePostResponseDto;
+import com.example.demo.dto.common.MusicVoResponseDto;
+import com.example.demo.dto.genre.GenreVoResponseDto;
+import com.example.demo.model.post.Genre;
+import com.example.demo.model.post.Music;
+import com.example.demo.security.TokenAuthenticationFilter;
+import com.example.demo.service.BattleService;
+import com.example.demo.service.PrincipalService;
+import com.example.demo.service.VoteService;
+
+@WithMockUser
+@ExtendWith({MockitoExtension.class})
+@AutoConfigureRestDocs
+@WebMvcTest(
+	value = BattleController.class,
+	excludeFilters = @ComponentScan.Filter(
+		type = FilterType.ASSIGNABLE_TYPE,
+		classes = TokenAuthenticationFilter.class
+	)
+)
+public class BattleDetailsListRestDocsTest {
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@MockBean
+	private PrincipalService principalService;
+
+	@MockBean
+	private BattleService battleService;
+
+	@MockBean
+	private VoteService voteService;
+
+	@Test
+	void 성공_모든_진행중인_대결들의_상세정보_리스트를_조회할_수_있다() throws Exception {
+		// given
+		BattleDetailsListResponseDto expected = createResponseDto();
+		// when
+		when(battleService.getBattleDetailsListInProgress())
+			.thenReturn(expected);
+		ResultActions actions = mockMvc.perform(get("/api/v1/battles")
+			.contentType(MediaType.APPLICATION_JSON));
+		// then
+		actions
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("success").value(true))
+			.andExpect(jsonPath("data").exists())
+			.andDo(document("success-find-all-battle-details-in-progress",
+				responseFields(
+					fieldWithPath("success").type(JsonFieldType.BOOLEAN)
+						.description("API 요청 성공 여부"),
+					fieldWithPath("message").type(JsonFieldType.STRING)
+						.description("API 요청 응답 메시지"),
+					fieldWithPath("data").type(JsonFieldType.OBJECT)
+						.description("API 요청 응답 데이터"),
+					fieldWithPath("data.battles").type(JsonFieldType.ARRAY)
+						.description("진행중인 모든 대결 상세정보 리스트"),
+					fieldWithPath("data.battles[].battleId").type(JsonFieldType.NUMBER)
+						.description("진행중인 대결 ID"),
+					fieldWithPath("data.battles[].battleGenre").type(JsonFieldType.OBJECT)
+						.description("대결의 장르"),
+					fieldWithPath("data.battles[].battleGenre.genreValue").type(JsonFieldType.STRING)
+						.description("대결의 장르 enum 값"),
+					fieldWithPath("data.battles[].battleGenre.genreName").type(JsonFieldType.STRING)
+						.description("대결의 장르명"),
+					fieldWithPath("data.battles[].challenged").type(JsonFieldType.OBJECT)
+						.description("대결 신청을 받은 게시물 대결 정보"),
+					fieldWithPath("data.battles[].challenged.postId").type(JsonFieldType.NUMBER)
+						.description("대결 신청을 받은 게시물 ID"),
+					fieldWithPath("data.battles[].challenged.music").type(JsonFieldType.OBJECT)
+						.description("대결 신청을 받은 게시물에서 공유한 음악 정보"),
+					fieldWithPath("data.battles[].challenged.music.musicId").type(JsonFieldType.STRING)
+						.description("대결 신청을 받은 게시물에서 공유한 음악의 고유 번호"),
+					fieldWithPath("data.battles[].challenged.music.singer").type(JsonFieldType.STRING)
+						.description("대결 신청을 받은 게시물에서 공유한 음악의 가수명"),
+					fieldWithPath("data.battles[].challenged.music.title").type(JsonFieldType.STRING)
+						.description("대결 신청을 받은 게시물에서 공유한 음악의 제목"),
+					fieldWithPath("data.battles[].challenged.music.genre").type(JsonFieldType.OBJECT)
+						.description("대결 신청을 받은 게시물에서 공유한 음악의 장르"),
+					fieldWithPath("data.battles[].challenged.music.genre.genreValue").type(JsonFieldType.STRING)
+						.description("대결 신청을 받은 게시물에서 공유한 음악의 장르 enum 값"),
+					fieldWithPath("data.battles[].challenged.music.genre.genreName").type(JsonFieldType.STRING)
+						.description("대결 신청을 받은 게시물에서 공유한 음악의 장르명"),
+					fieldWithPath("data.battles[].challenged.music.musicUrl").type(JsonFieldType.STRING)
+						.description("대결 신청을 받은 게시물에서 공유한 음악의 재생 URL"),
+					fieldWithPath("data.battles[].challenged.music.albumCoverUrl").type(JsonFieldType.STRING)
+						.description("대결 신청을 받은 게시물에서 공유한 음악의 앨범 커버 URL"),
+					fieldWithPath("data.battles[].challenging").type(JsonFieldType.OBJECT)
+						.description("대결을 신청한 게시물 대결 정보"),
+					fieldWithPath("data.battles[].challenging.postId").type(JsonFieldType.NUMBER)
+						.description("대결을 신청한 게시물 ID"),
+					fieldWithPath("data.battles[].challenging.music").type(JsonFieldType.OBJECT)
+						.description("대결을 신청한 게시물에서 공유한 음악 정보"),
+					fieldWithPath("data.battles[].challenging.music.musicId").type(JsonFieldType.STRING)
+						.description("대결을 신청한 게시물에서 공유한 음악의 고유 번호"),
+					fieldWithPath("data.battles[].challenging.music.singer").type(JsonFieldType.STRING)
+						.description("대결을 신청한 게시물에서 공유한 음악의 가수명"),
+					fieldWithPath("data.battles[].challenging.music.title").type(JsonFieldType.STRING)
+						.description("대결을 신청한 게시물에서 공유한 음악의 제목"),
+					fieldWithPath("data.battles[].challenging.music.genre").type(JsonFieldType.OBJECT)
+						.description("대결을 신청한 게시물에서 공유한 음악의 장르"),
+					fieldWithPath("data.battles[].challenging.music.genre.genreValue").type(JsonFieldType.STRING)
+						.description("대결을 신청한 게시물에서 공유한 음악의 장르 enum 값"),
+					fieldWithPath("data.battles[].challenging.music.genre.genreName").type(JsonFieldType.STRING)
+						.description("대결을 신청한 게시물에서 공유한 음악의 장르명"),
+					fieldWithPath("data.battles[].challenging.music.musicUrl").type(JsonFieldType.STRING)
+						.description("대결을 신청한 게시물에서 공유한 음악의 재생 URL"),
+					fieldWithPath("data.battles[].challenging.music.albumCoverUrl").type(JsonFieldType.STRING)
+						.description("대결을 신청한 게시물에서 공유한 음악의 앨범 커버 URL")
+				)));
+	}
+
+	private BattleDetailsListResponseDto createResponseDto() {
+		return new BattleDetailsListResponseDto(
+			List.of(
+				new BattleDetailsResponseDto(
+					1L,
+					GenreVoResponseDto.of(Genre.CLASSIC),
+					new BattlePostResponseDto(
+						1L,
+						MusicVoResponseDto.of(
+							new Music(
+								"ABCD1234",
+								"albumCoverUrl",
+								"singer",
+								"title",
+								Genre.CLASSIC,
+								"musicUrl"
+							)
+						)
+					),
+					new BattlePostResponseDto(
+						2L,
+						MusicVoResponseDto.of(
+							new Music(
+								"ABCD1235",
+								"albumCoverUrl2",
+								"singer2",
+								"title2",
+								Genre.CLASSIC,
+								"musicUrl2"
+							)
+						)
+					)
+				)
+			)
+		);
+	}
+}


### PR DESCRIPTION
## PR Description 🗒️

## 추가/변경 사항 및 설명 📝
- 대결 상세정보 리스트 조회에 대한 기능 코드 추가.
- Progress 상태인 모든 대결 게시글을 전부 가져옴.
- 이에 대한 통합 테스트 작성.
- RestDocs를 이용한 api 명세 작성.

## Issue close ✂️
#88 
