### PR TITLE
[FIX] 대결 숏폼 리스트 조회 시 유저가 투표한 리스트는 나오지 않게 수정.

### DIFF
--- a/src/main/java/com/example/demo/controller/BattleController.java
+++ b/src/main/java/com/example/demo/controller/BattleController.java
@@ -49,9 +49,9 @@ public class BattleController {
 			));
 	}
 
-	@GetMapping
-	public ResponseEntity<ApiResponse> getBattleDetailsList() {
-		BattleDetailsListResponseDto responseDto = battleService.getBattleDetailsListInProgress();
+	@GetMapping("/details")
+	public ResponseEntity<ApiResponse> getBattleDetailsList(Principal principal) {
+		BattleDetailsListResponseDto responseDto = battleService.getBattleDetailsListInProgress(principal);
 		return ResponseEntity.ok(
 			ApiResponse.success(
 				ResponseMessage.SUCCESS_FIND_ALL_BATTLE_DETAILS.getMessage(),

--- a/src/main/java/com/example/demo/model/battle/Vote.java
+++ b/src/main/java/com/example/demo/model/battle/Vote.java
@@ -67,7 +67,7 @@ public class Vote extends BaseEntity {
 
 	}
 
-	public boolean checkVotedBattle(Long battleId) {
+	public boolean hasBattle(Long battleId) {
 		return Objects.equals(battle.getId(), battleId);
 	}
 }

--- a/src/main/java/com/example/demo/model/battle/Vote.java
+++ b/src/main/java/com/example/demo/model/battle/Vote.java
@@ -66,4 +66,8 @@ public class Vote extends BaseEntity {
 		this.voter = voter;
 
 	}
+
+	public boolean checkVotedBattle(Long battleId) {
+		return Objects.equals(battle.getId(), battleId);
+	}
 }

--- a/src/main/java/com/example/demo/repository/VoteRepository.java
+++ b/src/main/java/com/example/demo/repository/VoteRepository.java
@@ -11,5 +11,6 @@ import com.example.demo.model.member.Member;
 public interface VoteRepository extends JpaRepository<Vote, Long> {
 
 	List<Vote> findAllByVoterId(Long voterId);
+
 	boolean existsByBattleAndVoter(Battle battle, Member voter);
 }

--- a/src/main/java/com/example/demo/repository/VoteRepository.java
+++ b/src/main/java/com/example/demo/repository/VoteRepository.java
@@ -1,8 +1,12 @@
 package com.example.demo.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.example.demo.model.battle.Vote;
 
 public interface VoteRepository extends JpaRepository<Vote, Long> {
+
+	List<Vote> findAllByVoterId(Long voterId);
 }

--- a/src/main/java/com/example/demo/service/BattleService.java
+++ b/src/main/java/com/example/demo/service/BattleService.java
@@ -17,12 +17,12 @@ import com.example.demo.dto.battle.BattleDetailsListResponseDto;
 import com.example.demo.model.battle.Battle;
 import com.example.demo.model.battle.BattleStatus;
 import com.example.demo.model.battle.Vote;
-import com.example.demo.repository.VoteRepository;
 import com.example.demo.model.member.Member;
 import com.example.demo.model.post.Genre;
 import com.example.demo.model.post.Post;
 import com.example.demo.repository.BattleRepository;
 import com.example.demo.repository.PostRepository;
+import com.example.demo.repository.VoteRepository;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/example/demo/service/BattleService.java
+++ b/src/main/java/com/example/demo/service/BattleService.java
@@ -52,18 +52,14 @@ public class BattleService {
 		List<Battle> battleListInProgress = battleRepository.findAllByStatusEquals(BattleStatus.PROGRESS);
 		List<Vote> votes = voteRepository.findAllByVoterId(member.getId());
 
-		List<Battle> notVotedBattleListInProgress = battleListInProgress.stream()
+		List<Battle> battleListInProgressNotVotedByMember = battleListInProgress.stream()
 			.filter(battle -> votes.stream()
-				.noneMatch(vote -> checkVotedBattle(vote, battle))
+				.noneMatch(vote -> vote.hasBattle(battle.getId()))
 			)
 			.toList();
 		return BattleDetailsListResponseDto.of(
-			notVotedBattleListInProgress
+			battleListInProgressNotVotedByMember
 		);
-	}
-
-	private boolean checkVotedBattle(Vote vote, Battle battle) {
-		return vote.checkVotedBattle(battle.getId());
 	}
 }
 

--- a/src/test/java/com/example/demo/controller/battle/BattleDetailsListRestDocsTest.java
+++ b/src/test/java/com/example/demo/controller/battle/BattleDetailsListRestDocsTest.java
@@ -6,6 +6,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.security.Principal;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -65,9 +66,9 @@ public class BattleDetailsListRestDocsTest {
 		// given
 		BattleDetailsListResponseDto expected = createResponseDto();
 		// when
-		when(battleService.getBattleDetailsListInProgress())
+		when(battleService.getBattleDetailsListInProgress(any(Principal.class)))
 			.thenReturn(expected);
-		ResultActions actions = mockMvc.perform(get("/api/v1/battles")
+		ResultActions actions = mockMvc.perform(get("/api/v1/battles/details")
 			.contentType(MediaType.APPLICATION_JSON));
 		// then
 		actions


### PR DESCRIPTION
## PR Description 🗒️

## 추가/변경 사항 및 설명 📝
- 로직에서 유저의 투표 리스트를 가져오고 이를 진행중인 대결들에서 필터링 -> 유저가 투표하지 않은 진행중인 대결 리스트 반환

## Issue close ✂️
#131
