### PR TITLE
[FIX] 마이페이지/유저페이지 유저 상세정보 (승수, 이름, 프로필 등) 구분해서 출력하도록 수정.

### DIFF
--- a/src/main/java/com/example/demo/common/ResponseMessage.java
+++ b/src/main/java/com/example/demo/common/ResponseMessage.java
@@ -4,13 +4,17 @@ import lombok.Getter;
 
 @Getter
 public enum ResponseMessage {
+	// Member
+	SUCCESS_FIND_BATTLE_BY_MEMBER("유저 참여 대결 정보 리스트 조회 성공"),
+	SUCCESS_MY_PAGE_PROFILE("마이페이지 상세정보 조회 성공"),
+	SUCCESS_USER_PAGE_PROFILE("유저페이지 상세정보 조회 성공"),
 	// Post
 	SUCCESS_CREATE_POST("음악 공유 게시글 등록 성공"),
 	SUCCESS_FIND_ALL_POST("음악 공유 게시글 리스트 조회 성공"),
 	SUCCESS_FIND_POST("음악 공유 게시글 상세 조회 성공"),
+	// Battle
 	SUCCESS_FIND_ALL_CANDIDATE_POST("대결곡 후보 게시글 리스트 조회 성공"),
 	SUCCESS_FIND_ALL_BATTLE_DETAILS("대결 상세 정보 리스트 조회 성공"),
-	SUCCESS_FIND_BATTLE_BY_MEMBER("유저 참여 대결 정보 리스트 조회 성공"),
 	SUCCESS_VOTE("대결 투표 성공");
 
 	final String message;

--- a/src/main/java/com/example/demo/dto/member/MemberMyDetailsResponseDto.java
+++ b/src/main/java/com/example/demo/dto/member/MemberMyDetailsResponseDto.java
@@ -5,20 +5,22 @@ import com.example.demo.model.member.Member;
 import lombok.Builder;
 
 @Builder
-public record MemberDetailsResponseDto(
+public record MemberMyDetailsResponseDto(
 	String nickname,
 	String profileImageUrl,
 	int ranking,
 	int victoryPoint,
-	int victoryCount
+	int victoryCount,
+	int countOfChanllenge
 ) {
-	public static MemberDetailsResponseDto of(Member member) {
-		return MemberDetailsResponseDto.builder()
+	public static MemberMyDetailsResponseDto of(Member member) {
+		return MemberMyDetailsResponseDto.builder()
 			.nickname(member.getNickname())
 			.profileImageUrl(member.getProfileImageUrl())
 			.ranking(member.getRanking())
 			.victoryPoint(member.getVictoryPoint())
 			.victoryCount(member.getVictoryCount())
+			.countOfChanllenge(member.getCountOfChallengeTicket())
 			.build();
 	}
 }

--- a/src/test/java/com/example/demo/controller/member/MemberDetailsRestDocsTest.java
+++ b/src/test/java/com/example/demo/controller/member/MemberDetailsRestDocsTest.java
@@ -5,6 +5,7 @@ import static com.example.demo.controller.TestUtil.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -76,7 +77,7 @@ public class MemberDetailsRestDocsTest {
 
 	@Test
 	@WithMockUser
-	public void 성공_유저_상세정보를_조회할_수_있다() throws Exception {
+	public void 성공_나의_상세정보를_조회할_수_있다() throws Exception {
 		// given
 		Member member = createMember();
 
@@ -95,7 +96,11 @@ public class MemberDetailsRestDocsTest {
 			.andExpect(jsonPath("success").value(true))
 			.andExpect(jsonPath("data").exists())
 			.andDo(print())
-			.andDo(document("success-find-member-details",
+			.andDo(document("success-find-my-details",
+				requestParameters(
+					parameterWithName("memberId").optional()
+						.description("멤버 ID (값이 없으면 마이페이지, 있으면 memberId로 들어오는 유저의 유저페이지)")
+				),
 				responseFields(
 					fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("API 요청 성공 여부"),
 					fieldWithPath("message").type(JsonFieldType.STRING).description("API 요청 응답 메시지"),
@@ -106,6 +111,46 @@ public class MemberDetailsRestDocsTest {
 					fieldWithPath("data.victoryPoint").type(JsonFieldType.NUMBER).description("획득한 승리 포인트"),
 					fieldWithPath("data.victoryCount").type(JsonFieldType.NUMBER).description("승리 횟수"),
 					fieldWithPath("data.countOfChanllenge").type(JsonFieldType.NUMBER).description("남은 대결권 개수")
+				)
+			));
+	}
+
+	@Test
+	@WithMockUser
+	public void 성공_유저의_상세정보를_조회할_수_있다() throws Exception {
+		// given
+		Member member = createMember();
+
+		// when
+		when(memberRepository.findById(anyLong()))
+			.thenReturn(Optional.of(member));
+		when(principalService.getMemberByPrincipal(any()))
+			.thenReturn(member);
+		var actions = mockMvc.perform(get("/api/v1/members/profile")
+			.contentType(MediaType.APPLICATION_JSON)
+			.param("memberId", "2")
+			.header("Authorization", "Bearer accessToken"));
+
+		// then
+		actions
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("success").value(true))
+			.andExpect(jsonPath("data").exists())
+			.andDo(print())
+			.andDo(document("success-find-member-details",
+				requestParameters(
+					parameterWithName("memberId").optional()
+						.description("멤버 ID (값이 없으면 마이페이지, 있으면 memberId로 들어오는 유저의 유저페이지)")
+				),
+				responseFields(
+					fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("API 요청 성공 여부"),
+					fieldWithPath("message").type(JsonFieldType.STRING).description("API 요청 응답 메시지"),
+					fieldWithPath("data").type(JsonFieldType.OBJECT).description("API 요청 응답 데이터"),
+					fieldWithPath("data.nickname").type(JsonFieldType.STRING).description("멤버 닉네임"),
+					fieldWithPath("data.profileImageUrl").type(JsonFieldType.STRING).description("프로필 이미지 URL"),
+					fieldWithPath("data.ranking").type(JsonFieldType.NUMBER).description("멤버 랭킹"),
+					fieldWithPath("data.victoryPoint").type(JsonFieldType.NUMBER).description("획득한 승리 포인트"),
+					fieldWithPath("data.victoryCount").type(JsonFieldType.NUMBER).description("승리 횟수")
 				)
 			));
 	}

--- a/src/test/java/com/example/demo/controller/member/MemberDetailsTest.java
+++ b/src/test/java/com/example/demo/controller/member/MemberDetailsTest.java
@@ -56,7 +56,7 @@ public class MemberDetailsTest {
 		// when
 		when(memberRepository.findById(anyLong())).thenReturn(Optional.of(member));
 		ResponseEntity<ApiResponse> responseEntity = memberController.getMemberProfile(authentication,
-			Optional.of(2L));
+			Optional.of(1L));
 
 		// then
 		assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -74,7 +74,7 @@ public class MemberDetailsTest {
 		// when
 		when(memberRepository.findById(anyLong())).thenReturn(Optional.of(member));
 		ResponseEntity<ApiResponse> responseEntity = memberController.getMemberProfile(authentication,
-			Optional.of(1L));
+			Optional.of(2L));
 
 		// then
 		assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);

--- a/src/test/java/com/example/demo/controller/member/MemberDetailsTest.java
+++ b/src/test/java/com/example/demo/controller/member/MemberDetailsTest.java
@@ -47,6 +47,24 @@ public class MemberDetailsTest {
 	}
 
 	@Test
+	public void 성공_나의_세부정보를_조회할_수_있다() {
+		// given
+		Member member = createMember();
+		UserDetails userDetails = createValidUserDetails();
+		TestAuthentication authentication = new TestAuthentication(userDetails);
+
+		// when
+		when(memberRepository.findById(anyLong())).thenReturn(Optional.of(member));
+		ResponseEntity<ApiResponse> responseEntity = memberController.getMemberProfile(authentication,
+			Optional.of(2L));
+
+		// then
+		assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(responseEntity.getBody().success()).isTrue();
+		assertThat(responseEntity.getBody().data()).isNotNull();
+	}
+
+	@Test
 	public void 성공_유저_세부정보를_조회할_수_있다() {
 		// given
 		Member member = createMember();
@@ -55,7 +73,8 @@ public class MemberDetailsTest {
 
 		// when
 		when(memberRepository.findById(anyLong())).thenReturn(Optional.of(member));
-		ResponseEntity<ApiResponse> responseEntity = memberController.getMemberProfile(authentication);
+		ResponseEntity<ApiResponse> responseEntity = memberController.getMemberProfile(authentication,
+			Optional.of(1L));
 
 		// then
 		assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -75,7 +94,7 @@ public class MemberDetailsTest {
 
 		// then
 		assertThatThrownBy(() -> {
-			memberController.getMemberProfile(authentication);
+			memberController.getMemberProfile(authentication, Optional.of(1L));
 		})
 			.isExactlyInstanceOf(EntityNotFoundException.class);
 	}


### PR DESCRIPTION
## PR Description 🗒️

## 추가/변경 사항 및 설명 📝
- 마이페이지/유저페이지 내려주는 데이터를 다르게 처리하기 위한 분기 추가.

## Issue close ✂️
#135 