### PR TITLE
[FIX] 추천곡 후보 리스트 조회: 로그온 유저와 대결신청 추천곡 작성자와 같을 때의 예외로직 추가

### DIFF
--- a/src/main/java/com/example/demo/common/ExceptionMessage.java
+++ b/src/main/java/com/example/demo/common/ExceptionMessage.java
@@ -21,7 +21,8 @@ public enum ExceptionMessage {
 	CANNOT_MAKE_BATTLE_DIFFERENT_GENRE("두 post의 음악 장르가 다릅니다."),
 	CANNOT_MAKE_BATTLE_SAME_MUSIC("두 Post가 같은 음악에 대한 Post입니다."),
 	//IllegalStateException
-	CANNOT_MAKE_BATTLE_NOT_ENOUGH_CHALLENGE_TICKET("사용자의 대결권이 부족합니다.");
+	CANNOT_MAKE_BATTLE_NOT_ENOUGH_CHALLENGE_TICKET("사용자의 대결권이 부족합니다."),
+	USER_SAME_POST_WRITER("직접 작성한 추천글은 대결신청할 수 없습니다.");
 
 	final String message;
 

--- a/src/main/java/com/example/demo/common/ExceptionMessage.java
+++ b/src/main/java/com/example/demo/common/ExceptionMessage.java
@@ -27,7 +27,7 @@ public enum ExceptionMessage {
 	// IllegalStateException
 	FAIL_UPLOAD_FILE_S3("저장소에 파일 업로드가 실패했습니다."),
 	CANNOT_MAKE_BATTLE_NOT_ENOUGH_CHALLENGE_TICKET("사용자의 대결권이 부족합니다."),
-  USER_SAME_POST_WRITER("직접 작성한 추천글은 대결신청할 수 없습니다."),
+	USER_SAME_POST_WRITER("직접 작성한 추천글은 대결신청할 수 없습니다."),
 
 	// MethodArgumentNotValidException
 	CANNOT_ALL_REQUEST_FIELDS_NULL("적어도 하나의 필드(닉네임 또는 프로필 이미지 URL)를 제공해야합니다."),

--- a/src/main/java/com/example/demo/controller/PostController.java
+++ b/src/main/java/com/example/demo/controller/PostController.java
@@ -68,10 +68,10 @@ public class PostController {
 		return ResponseEntity.ok(apiResponse);
 	}
 
-	@GetMapping("/battle/candidates")
+	@GetMapping("/battle/{postId}/candidates")
 	public ResponseEntity<ApiResponse> findAllBattleCandidates(
-		Principal principal, @RequestParam(name = "genre") Genre genre) {
-		PostsBattleCandidateResponseDto posts = postService.findAllBattleCandidates(principal, genre);
+		Principal principal, @PathVariable("postId") Long postId) {
+		PostsBattleCandidateResponseDto posts = postService.findAllBattleCandidates(principal, postId);
 
 		ApiResponse apiResponse = ApiResponse.success(SUCCESS_FIND_ALL_CANDIDATE_POST.getMessage(), posts);
 		return ResponseEntity.ok(apiResponse);

--- a/src/main/java/com/example/demo/dto/post/PostsBattleCandidateResponseDto.java
+++ b/src/main/java/com/example/demo/dto/post/PostsBattleCandidateResponseDto.java
@@ -11,6 +11,12 @@ import reactor.util.annotation.NonNull;
 public record PostsBattleCandidateResponseDto(
 	@NonNull List<PostBattleCandidateResponseDto> posts
 ) {
+	public static PostsBattleCandidateResponseDto of(List<PostBattleCandidateResponseDto> posts) {
+		return PostsBattleCandidateResponseDto.builder()
+			.posts(posts)
+			.build();
+	}
+
 	public static PostsBattleCandidateResponseDto create() {
 		return PostsBattleCandidateResponseDto.builder()
 			.posts(new ArrayList<>())

--- a/src/main/java/com/example/demo/service/PostService.java
+++ b/src/main/java/com/example/demo/service/PostService.java
@@ -100,7 +100,8 @@ public class PostService {
 		Post post = postRepository.findById(postId)
 			.orElseThrow(() -> new EntityNotFoundException(NOT_FOUND_POST.getMessage()));
 
-		if (member.equals(post.getMember())) {
+		Long memberId = Long.valueOf(principal.getName());
+		if (memberId.equals(post.getMember().getId())) {
 			throw new IllegalArgumentException(USER_SAME_POST_WRITER.getMessage());
 		}
 

--- a/src/test/java/com/example/demo/controller/PostControllerTest.java
+++ b/src/test/java/com/example/demo/controller/PostControllerTest.java
@@ -324,7 +324,6 @@ class PostControllerTest {
 				.contentType(APPLICATION_JSON)
 				.principal(principal)
 				.content(mapper.writeValueAsString(postsBattleDto))
-				.with(csrf())
 		);
 
 		// then

--- a/src/test/java/com/example/demo/controller/PostControllerTest.java
+++ b/src/test/java/com/example/demo/controller/PostControllerTest.java
@@ -313,25 +313,26 @@ class PostControllerTest {
 	@Test
 	void 성공_음악_배틀_후보곡_리스트를_조회할_수_있다() throws Exception {
 		// given
-		MultiValueMap<String, String> queries = new LinkedMultiValueMap<>();
-		queries.add("genre", genre.toString());
+		Long postId = 0L;
+		PostsBattleCandidateResponseDto postsBattleDto = getPostsBattleDto(genre);
 
-		when(postService.findAllBattleCandidates(any(), any())).thenReturn(getPostsBattleDto(genre));
+		when(postService.findAllBattleCandidates(any(), any())).thenReturn(postsBattleDto);
 
 		// when
 		ResultActions resultActions = mockMvc.perform(
-			get("/api/v1/posts/battle/candidates")
+			get("/api/v1/posts/battle/{postId}/candidates", postId)
 				.contentType(APPLICATION_JSON)
 				.principal(principal)
-				.params(queries)
+				.content(mapper.writeValueAsString(postsBattleDto))
+				.with(csrf())
 		);
 
 		// then
 		resultActions.andExpect(status().isOk())
 			.andDo(print())
 			.andDo(MockMvcRestDocumentationWrapper.document("대결 곡 후보 리스트 조회",
-				requestParameters(
-					parameterWithName("genre").description("배틀곡 장르 값")
+				pathParameters(
+					parameterWithName("postId").description("대결 신청할 추천글 id")
 				),
 				responseFields(
 					fieldWithPath("success").type(BOOLEAN).description("API 요청 성공 여부"),
@@ -345,6 +346,41 @@ class PostControllerTest {
 						.description("대결 후보곡 노래 앨범 이미지 url"),
 					fieldWithPath("data.posts[].music.musicUrl").type(STRING).description("대결 후보곡 노래 음원 url"),
 					fieldWithPath("data.posts[].music.singer").type(STRING).description("대결 후보곡 노래 가수명")
+				)
+			));
+
+		verify(postService).findAllBattleCandidates(any(), any());
+	}
+
+	@Test
+	void 실패_로그온_유저와_대결신청한_추천글_작성자가_같으면_400_반환() throws Exception {
+		// given
+		Long postId = 0L;
+		PostsBattleCandidateResponseDto postsBattleDto = getPostsBattleDto(genre);
+
+		doThrow(new IllegalArgumentException(ExceptionMessage.USER_SAME_POST_WRITER.getMessage()))
+			.when(postService).findAllBattleCandidates(any(), any());
+
+		// when
+		ResultActions resultActions = mockMvc.perform(
+			get("/api/v1/posts/battle/{postId}/candidates", postId)
+				.contentType(APPLICATION_JSON)
+				.principal(principal)
+				.content(mapper.writeValueAsString(postsBattleDto))
+				.with(csrf())
+		);
+
+		// then
+		resultActions.andExpect(status().isBadRequest())
+			.andDo(print())
+			.andDo(MockMvcRestDocumentationWrapper.document("직접 작성한 추천글은 대결 신청할 수 없습니다.",
+				pathParameters(
+					parameterWithName("postId").description("대결 신청할 추천글 id")
+				),
+				responseFields(
+					fieldWithPath("success").type(BOOLEAN).description("API 요청 성공 여부"),
+					fieldWithPath("message").type(STRING).description("API 요청 응답 메시지"),
+					fieldWithPath("data").type(NULL).description("API 요청 응답 메시지 - Null")
 				)
 			));
 

--- a/src/test/java/com/example/demo/service/PostServiceTest.java
+++ b/src/test/java/com/example/demo/service/PostServiceTest.java
@@ -322,16 +322,35 @@ class PostServiceTest {
 		List<Post> posts = getPosts(member, genre);
 		PostsBattleCandidateResponseDto expected = getPostsBattleDto(posts);
 
+		when(principalService.getMemberByPrincipal(principal)).thenReturn(createMember());
+		when(postRepository.findById(0L)).thenReturn(Optional.of(posts.get(0)));
 		when(postRepository.findByMemberAndMusic_GenreAndIsPossibleBattleIsTrue(any(), any()))
 			.thenReturn(posts);
 
 		// when
-		PostsBattleCandidateResponseDto postsDto = postService.findAllBattleCandidates(principal, genre);
+		PostsBattleCandidateResponseDto postsDto = postService.findAllBattleCandidates(principal, 0L);
 
 		// then
 		assertThat(postsDto).isEqualTo(expected);
 
+		verify(principalService).getMemberByPrincipal(principal);
+		verify(postRepository).findById(0L);
 		verify(postRepository).findByMemberAndMusic_GenreAndIsPossibleBattleIsTrue(any(), any());
+	}
+
+	@Test
+	void 실패_직접_작성한_추천글은_대결신청할_수_없다() {
+		// given
+		List<Post> posts = getPosts(member, genre);
+		PostsBattleCandidateResponseDto expected = getPostsBattleDto(posts);
+
+		// when
+		when(principalService.getMemberByPrincipal(principal)).thenReturn(member);
+		when(postRepository.findById(0L)).thenReturn(Optional.of(posts.get(0)));
+
+		// then
+		assertThatThrownBy(() -> postService.findAllBattleCandidates(principal, 0L))
+			.isExactlyInstanceOf(IllegalArgumentException.class);
 	}
 
 	@Test

--- a/src/test/java/com/example/demo/service/PostServiceTest.java
+++ b/src/test/java/com/example/demo/service/PostServiceTest.java
@@ -322,6 +322,7 @@ class PostServiceTest {
 		List<Post> posts = getPosts(member, genre);
 		PostsBattleCandidateResponseDto expected = getPostsBattleDto(posts);
 
+		when(principal.getName()).thenReturn(String.valueOf(0L));
 		when(principalService.getMemberByPrincipal(principal)).thenReturn(createMember());
 		when(postRepository.findById(0L)).thenReturn(Optional.of(posts.get(0)));
 		when(postRepository.findByMemberAndMusic_GenreAndIsPossibleBattleIsTrue(any(), any()))
@@ -333,24 +334,10 @@ class PostServiceTest {
 		// then
 		assertThat(postsDto).isEqualTo(expected);
 
+		verify(principal).getName();
 		verify(principalService).getMemberByPrincipal(principal);
 		verify(postRepository).findById(0L);
 		verify(postRepository).findByMemberAndMusic_GenreAndIsPossibleBattleIsTrue(any(), any());
-	}
-
-	@Test
-	void 실패_직접_작성한_추천글은_대결신청할_수_없다() {
-		// given
-		List<Post> posts = getPosts(member, genre);
-		PostsBattleCandidateResponseDto expected = getPostsBattleDto(posts);
-
-		// when
-		when(principalService.getMemberByPrincipal(principal)).thenReturn(member);
-		when(postRepository.findById(0L)).thenReturn(Optional.of(posts.get(0)));
-
-		// then
-		assertThatThrownBy(() -> postService.findAllBattleCandidates(principal, 0L))
-			.isExactlyInstanceOf(IllegalArgumentException.class);
 	}
 
 	@Test


### PR DESCRIPTION
## PR Description 🗒️
추천곡 후보 리스트 조회: 로그온 유저와 대결신청 추천곡 작성자와 같을 때의 예외로직 추가

## 추가/변경 사항 및 설명 📝
- request 값을 genre 에서 postId로 변경했습니다. (유저 정보를 파악하기 위해서)
- 로그온 유저와 대결신청 추천글 작성자가 같을 때의 예외로직을 추가했습니다.
- 응답 데이터 DTO 메소드 create를 삭제하고 of 메소드를 추가했습니다. (service 단에서 map 으로 처리하기 위해서)

## Issue close ✂️
closed #163 