### PR TITLE
[FEAT] 추천글 좋아요 상위 10개 조회 기능 구현 및 테스트

### DIFF
--- a/src/main/java/com/example/demo/controller/PostController.java
+++ b/src/main/java/com/example/demo/controller/PostController.java
@@ -92,4 +92,14 @@ public class PostController {
 		return ResponseEntity.ok(apiResponse);
 	}
 
+	@GetMapping("/likes/top/10")
+	public ResponseEntity<ApiResponse> findTenPostsByLikeCount(
+		@RequestParam(name = "genre", required = false) Genre genre) {
+		PostsFindResponseDto result = postService.findTenPostsByLikeCount(genre);
+
+		ApiResponse apiResponse = ApiResponse.success(SUCCESS_FIND_ALL_POST.getMessage(), result);
+
+		return ResponseEntity.ok(apiResponse);
+	}
+
 }

--- a/src/main/java/com/example/demo/controller/PostController.java
+++ b/src/main/java/com/example/demo/controller/PostController.java
@@ -92,7 +92,7 @@ public class PostController {
 		return ResponseEntity.ok(apiResponse);
 	}
 
-	@GetMapping("/likes/top/10")
+	@GetMapping("/likes/top")
 	public ResponseEntity<ApiResponse> findTenPostsByLikeCount(
 		@RequestParam(name = "genre", required = false) Genre genre) {
 		PostsFindResponseDto result = postService.findTenPostsByLikeCount(genre);

--- a/src/main/java/com/example/demo/service/PostService.java
+++ b/src/main/java/com/example/demo/service/PostService.java
@@ -3,6 +3,7 @@ package com.example.demo.service;
 import static com.example.demo.common.ExceptionMessage.*;
 
 import java.security.Principal;
+import java.util.List;
 
 import javax.persistence.EntityNotFoundException;
 
@@ -117,5 +118,27 @@ public class PostService {
 			post.plusLike();
 			return PostLikeResponseDto.of(true);
 		}
+	}
+
+	public PostsFindResponseDto findTenPostsByLikeCount(Genre genre) {
+		Sort sort = Sort.by(Sort.Direction.DESC, "likeCount");
+
+		List<PostFindResponseDto> posts;
+
+		if (genre == null) {
+			posts = postRepository.findAll(sort)
+				.stream().map(PostFindResponseDto::of)
+				.toList();
+		} else {
+			posts = postRepository.findByMusic_Genre(genre, sort)
+				.stream().map(PostFindResponseDto::of)
+				.toList();
+		}
+
+		if (posts.size() > 10) {
+			return PostsFindResponseDto.of(posts.subList(0, 10));
+		}
+
+		return PostsFindResponseDto.of(posts);
 	}
 }

--- a/src/main/java/com/example/demo/service/PostService.java
+++ b/src/main/java/com/example/demo/service/PostService.java
@@ -36,6 +36,8 @@ public class PostService {
 	private final LikeRepository likeRepository;
 	private final PrincipalService principalService;
 
+	private final int topLimit = 10;
+
 	@Transactional
 	public Long createPost(Principal principal, PostCreateRequestDto postRequestDto) {
 		Member member = principalService.getMemberByPrincipal(principal);
@@ -135,8 +137,8 @@ public class PostService {
 				.toList();
 		}
 
-		if (posts.size() > 10) {
-			return PostsFindResponseDto.of(posts.subList(0, 10));
+		if (posts.size() > topLimit) {
+			return PostsFindResponseDto.of(posts.subList(0, topLimit));
 		}
 
 		return PostsFindResponseDto.of(posts);

--- a/src/test/java/com/example/demo/controller/PostControllerTest.java
+++ b/src/test/java/com/example/demo/controller/PostControllerTest.java
@@ -386,6 +386,64 @@ class PostControllerTest {
 		verify(postLockFacade).likePost((Principal)any(), anyLong());
 	}
 
+	@Test
+	void 성공_추천글을_좋아요_상위_10개를_가져올_수_있다() throws Exception {
+		// given
+		MultiValueMap<String, String> queries = new LinkedMultiValueMap<>();
+		queries.add("genre", genre.toString());
+
+		List<Post> posts = new ArrayList<>();
+		for (int i = 0; i < 10; i++) {
+			Post post = Post.create(musicId, albumCoverUrl, singer, musicName, genre, musicUrl,
+				content, isPossibleBattle, member);
+			for (int j = 0; j < 10 - i; j++) {
+				post.plusLike();
+			}
+			posts.add(post);
+		}
+
+		PostsFindResponseDto postsFindResponseDto = PostsFindResponseDto.of(
+			posts.stream().map(this::testOf).toList());
+
+		when(postService.findTenPostsByLikeCount(genre)).thenReturn(postsFindResponseDto);
+
+		// when
+		ResultActions resultActions = mockMvc.perform(
+			get("/api/v1/posts/likes/top/10")
+				.contentType(APPLICATION_JSON)
+				.params(queries)
+		);
+
+		// then
+		resultActions.andExpect(status().isOk())
+			.andDo(print())
+			.andDo(MockMvcRestDocumentationWrapper.document("추천글 좋아요 상위 10개 조회",
+				requestParameters(
+					parameterWithName("genre").optional().description("필터링 할 장르 값 (null 가능)")
+				),
+				responseFields(
+					fieldWithPath("success").type(BOOLEAN).description("API 요청 성공 여부"),
+					fieldWithPath("message").type(STRING).description("API 요청 응답 메시지"),
+					fieldWithPath("data").type(OBJECT).description("API 요청 응답 데이터"),
+					fieldWithPath("data.posts[]").type(ARRAY).description("조회한 공유글 정보 리스트"),
+					fieldWithPath("data.posts[].postId").type(NUMBER).description("조회한 공유글 id"),
+					fieldWithPath("data.posts[].music").type(OBJECT).description("조회한 공유글 음악 정보"),
+					fieldWithPath("data.posts[].music.title").type(STRING).description("조회한 공유글 음악 제목"),
+					fieldWithPath("data.posts[].music.albumCoverUrl").type(STRING)
+						.description("조회한 공유글 음악 앨범 표지 이미지 url"),
+					fieldWithPath("data.posts[].music.singer").type(STRING).description("조회한 공유글 음악 가수명"),
+					fieldWithPath("data.posts[].music.genre").type(OBJECT).description("조회한 공유글 음악 장르 정보"),
+					fieldWithPath("data.posts[].music.genre.genreValue").type(STRING).description("조회한 공유글 음악 장르값"),
+					fieldWithPath("data.posts[].music.genre.genreName").type(STRING).description("조회한 공유글 음악 장르명"),
+					fieldWithPath("data.posts[].likeCount").type(NUMBER).description("조회한 공유글의 좋아요 수"),
+					fieldWithPath("data.posts[].isBattlePossible").type(BOOLEAN).description("조회한 공유글 대결 가능 여부"),
+					fieldWithPath("data.posts[].nickname").type(STRING).description("조회한 공유글 작성자 이름")
+				)
+			));
+
+		verify(postService).findTenPostsByLikeCount(genre);
+	}
+
 	private Member createMember() {
 		return Member.builder()
 			.profileImageUrl("profile")

--- a/src/test/java/com/example/demo/controller/PostControllerTest.java
+++ b/src/test/java/com/example/demo/controller/PostControllerTest.java
@@ -409,7 +409,7 @@ class PostControllerTest {
 
 		// when
 		ResultActions resultActions = mockMvc.perform(
-			get("/api/v1/posts/likes/top/10")
+			get("/api/v1/posts/likes/top")
 				.contentType(APPLICATION_JSON)
 				.params(queries)
 		);

--- a/src/test/java/com/example/demo/repository/PostRepositoryTest.java
+++ b/src/test/java/com/example/demo/repository/PostRepositoryTest.java
@@ -220,6 +220,58 @@ class PostRepositoryTest {
 
 	}
 
+	@Test
+	@Transactional
+	void 성공_추천글을_좋아요_수_상위_10개를_가져올_수_있다() {
+		// given
+		List<Post> posts = new ArrayList<>();
+		for (int i = 0; i < 10; i++) {
+			Post post = Post.create("1234", "album", "singer", "title", genre,
+				"url", "content", isPossibleBattle, member);
+			for (int j = 0; j < i; j++) {
+				post.plusLike();
+			}
+			posts.add(post);
+		}
+
+		memberRepository.save(member);
+		postRepository.saveAll(posts);
+
+		Collections.reverse(posts);
+
+		// when
+		List<Post> result = postRepository.findAll(Sort.by(Sort.Direction.DESC, "likeCount"));
+
+		// then
+		assertThat(result).isEqualTo(posts);
+	}
+
+	@Test
+	@Transactional
+	void 성공_추천글을_장르별_좋아요_수_상위_10개를_가져올_수_있다() {
+		// given
+		List<Post> posts = new ArrayList<>();
+		for (int i = 0; i < 10; i++) {
+			Post post = Post.create("1234", "album", "singer", "title", genre,
+				"url", "content", isPossibleBattle, member);
+			for (int j = 0; j < i; j++) {
+				post.plusLike();
+			}
+			posts.add(post);
+		}
+
+		memberRepository.save(member);
+		postRepository.saveAll(posts);
+
+		Collections.reverse(posts);
+
+		// when
+		List<Post> result = postRepository.findByMusic_Genre(genre, Sort.by(Sort.Direction.DESC, "likeCount"));
+
+		// then
+		assertThat(result).isEqualTo(posts);
+	}
+
 	private Member createMember() {
 		return Member.builder()
 			.profileImageUrl("profile")

--- a/src/test/java/com/example/demo/service/PostServiceTest.java
+++ b/src/test/java/com/example/demo/service/PostServiceTest.java
@@ -373,6 +373,68 @@ class PostServiceTest {
 		verify(likeRepository).existsByMemberAndPost(member, post);
 	}
 
+	@Test
+	void 성공_전체_좋아요_상위_10개_추천글_조회() {
+		// given
+		List<Post> posts = new ArrayList<>();
+		for (int i = 0; i < 10; i++) {
+			Post post = Post.create(musicId, albumCoverUrl, singer, musicName, genre, musicUrl,
+				content, isPossibleBattle, member);
+			for (int j = 0; j < 10 - i; j++) {
+				post.plusLike();
+			}
+			posts.add(post);
+		}
+
+		PostsFindResponseDto postsFindResponseDto = PostsFindResponseDto.of(
+			posts.stream().map(PostFindResponseDto::of).toList()
+		);
+
+		Sort sort = Sort.by(Sort.Direction.DESC, "likeCount");
+
+		// when
+		when(postRepository.findAll(sort)).thenReturn(posts);
+
+		PostsFindResponseDto result = postService.findTenPostsByLikeCount(null);
+
+		// then
+		assertThat(result).isEqualTo(postsFindResponseDto);
+
+		verify(postRepository).findAll(sort);
+	}
+
+	@Test
+	void 성공_장르별_좋아요_상위_10개_추천글_조회() {
+		// given
+		List<Post> posts = new ArrayList<>();
+		for (int i = 0; i < 11; i++) {
+			Post post = Post.create(musicId, albumCoverUrl, singer, musicName, genre, musicUrl,
+				content, isPossibleBattle, member);
+			for (int j = 0; j < 11 - i; j++) {
+				post.plusLike();
+			}
+			posts.add(post);
+		}
+
+		Sort sort = Sort.by(Sort.Direction.DESC, "likeCount");
+
+		// when
+		when(postRepository.findByMusic_Genre(genre, sort)).thenReturn(posts);
+
+		PostsFindResponseDto result = postService.findTenPostsByLikeCount(genre);
+
+		posts.remove(posts.size() - 1);
+		PostsFindResponseDto postsFindResponseDto = PostsFindResponseDto.of(
+			posts.stream().map(PostFindResponseDto::of).toList()
+		);
+
+		// then
+		assertThat(result.posts().size()).isEqualTo(10);
+		assertThat(result).isEqualTo(postsFindResponseDto);
+
+		verify(postRepository).findByMusic_Genre(genre, sort);
+	}
+
 	private List<Post> getPosts(Member member, Genre genre) {
 		List<Post> posts = new ArrayList<>();
 		for (int i = 0; i < 5; i++) {


### PR DESCRIPTION
## PR Description 🗒️
추천글 좋아요 상위 10개 조회 기능 구현 및 테스트

## 추가/변경 사항 및 설명 📝
추천글을 좋아요 기준 상위 최대 10개를 가져오는 기능을 구현 및 테스트 했습니다.
응답 데이터 형식은 추천글 전체 조회 응답 데이터와 동일합니다.

## Issue close ✂️
closed #165 