### PR TITLE
[FIX] 대결 상세조회 관련 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/common/ExceptionMessage.java
+++ b/src/main/java/com/example/demo/common/ExceptionMessage.java
@@ -32,7 +32,10 @@ public enum ExceptionMessage {
 	CANNOT_ALL_REQUEST_FIELDS_NULL("적어도 하나의 필드(닉네임 또는 프로필 이미지 URL)를 제공해야합니다."),
 	CANNOT_NICKNAME_LENGTH_OVER_24("닉네임은 24자를 초과할 수 없습니다."),
 	NOT_EXIST_FILE_NAME("파일명이 존재하지 않습니다."),
-	CANNOT_NICKNAME_BLANK("닉네임은 공백만으로 이루어 질 수 없습니다.");
+	CANNOT_NICKNAME_BLANK("닉네임은 공백만으로 이루어 질 수 없습니다."),
+
+	//NumberFormatException
+	CANNOT_ACCESS_ANONYMOUS("로그인 하지 않은 사용자는 접근할 수 없습니다.");
 
 	final String message;
 

--- a/src/main/java/com/example/demo/controller/BattleController.java
+++ b/src/main/java/com/example/demo/controller/BattleController.java
@@ -78,8 +78,11 @@ public class BattleController {
 	}
 
 	@GetMapping("/{battleId}")
-	public ResponseEntity<ApiResponse> getBattleDetailByBattleId(@PathVariable Long battleId) {
-		BattleDetailByIdResponseDto battleDetailResponseDto = battleService.getBattleDetailById(battleId);
+	public ResponseEntity<ApiResponse> getBattleDetailByBattleId(
+		Principal principal,
+		@PathVariable Long battleId
+	) {
+		BattleDetailByIdResponseDto battleDetailResponseDto = battleService.getBattleDetailById(principal, battleId);
 		ApiResponse success = ApiResponse.success(SUCCESS_FIND_BATTLE_DETAIL_BY_ID.getMessage(),
 			battleDetailResponseDto);
 		return ResponseEntity.ok(success);

--- a/src/main/java/com/example/demo/controller/GlobalControllerAdvice.java
+++ b/src/main/java/com/example/demo/controller/GlobalControllerAdvice.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.example.demo.common.ApiResponse;
+import com.example.demo.common.ExceptionMessage;
 
 @RestControllerAdvice
 public class GlobalControllerAdvice {
@@ -34,6 +35,12 @@ public class GlobalControllerAdvice {
 	@ExceptionHandler(OAuth2AuthenticationException.class)
 	public ResponseEntity<ApiResponse> handleOAuth2AuthenticationException(OAuth2AuthenticationException exception) {
 		ApiResponse apiResponse = ApiResponse.fail(exception.getMessage());
+		return new ResponseEntity<>(apiResponse, HttpStatus.UNAUTHORIZED);
+	}
+
+	@ExceptionHandler(NumberFormatException.class)
+	public ResponseEntity<ApiResponse> handleNumberFormatException(NumberFormatException exception) {
+		ApiResponse apiResponse = ApiResponse.fail(ExceptionMessage.CANNOT_ACCESS_ANONYMOUS.getMessage());
 		return new ResponseEntity<>(apiResponse, HttpStatus.UNAUTHORIZED);
 	}
 }

--- a/src/main/java/com/example/demo/dto/battle/BattleDetailByIdResponseDto.java
+++ b/src/main/java/com/example/demo/dto/battle/BattleDetailByIdResponseDto.java
@@ -10,17 +10,19 @@ import lombok.Builder;
 public record BattleDetailByIdResponseDto(
 	Long battleId,
 	boolean isProgress,
+	boolean isVoted,
 	GenreVoResponseDto battleGenre,
 	BattlePostInfoWithVoteCntResponseVo challenged,
 	BattlePostInfoWithVoteCntResponseVo challenging
 ) {
-	public static BattleDetailByIdResponseDto of(Battle battle) {
+	public static BattleDetailByIdResponseDto of(Battle battle, boolean isVoted) {
 		BattleInfo challengedBattleInfo = battle.getChallengedPost();
 		BattleInfo challengingBattleInfo = battle.getChallengingPost();
 		if (battle.isProgress()) {
 			return BattleDetailByIdResponseDto.builder()
 				.battleId(battle.getId())
 				.isProgress(true)
+				.isVoted(isVoted)
 				.battleGenre(GenreVoResponseDto.of(battle.getGenre()))
 				.challenging(
 					BattlePostInfoWithVoteCntResponseVo
@@ -34,6 +36,7 @@ public record BattleDetailByIdResponseDto(
 			return BattleDetailByIdResponseDto.builder()
 				.battleId(battle.getId())
 				.isProgress(false)
+				.isVoted(isVoted)
 				.battleGenre(GenreVoResponseDto.of(battle.getGenre()))
 				.challenging(
 					BattlePostInfoWithVoteCntResponseVo

--- a/src/main/java/com/example/demo/dto/battle/BattleDetailByIdResponseDto.java
+++ b/src/main/java/com/example/demo/dto/battle/BattleDetailByIdResponseDto.java
@@ -15,14 +15,14 @@ public record BattleDetailByIdResponseDto(
 	BattlePostInfoWithVoteCntResponseVo challenged,
 	BattlePostInfoWithVoteCntResponseVo challenging
 ) {
-	public static BattleDetailByIdResponseDto of(Battle battle, boolean isVoted) {
+	public static BattleDetailByIdResponseDto ofVotedBattleDetail(Battle battle) {
 		BattleInfo challengedBattleInfo = battle.getChallengedPost();
 		BattleInfo challengingBattleInfo = battle.getChallengingPost();
 		if (battle.isProgress()) {
 			return BattleDetailByIdResponseDto.builder()
 				.battleId(battle.getId())
 				.isProgress(true)
-				.isVoted(isVoted)
+				.isVoted(true)
 				.battleGenre(GenreVoResponseDto.of(battle.getGenre()))
 				.challenging(
 					BattlePostInfoWithVoteCntResponseVo
@@ -36,7 +36,40 @@ public record BattleDetailByIdResponseDto(
 			return BattleDetailByIdResponseDto.builder()
 				.battleId(battle.getId())
 				.isProgress(false)
-				.isVoted(isVoted)
+				.isVoted(true)
+				.battleGenre(GenreVoResponseDto.of(battle.getGenre()))
+				.challenging(
+					BattlePostInfoWithVoteCntResponseVo
+						.ofWithVoteCnt(challengingBattleInfo.getPost(), challengingBattleInfo.getVoteCount()))
+				.challenged(
+					BattlePostInfoWithVoteCntResponseVo
+						.ofWithVoteCnt(challengedBattleInfo.getPost(), challengedBattleInfo.getVoteCount()))
+				.build();
+		}
+	}
+
+	public static BattleDetailByIdResponseDto ofNotVotedBattleDetail(Battle battle) {
+		BattleInfo challengedBattleInfo = battle.getChallengedPost();
+		BattleInfo challengingBattleInfo = battle.getChallengingPost();
+		if (battle.isProgress()) {
+			return BattleDetailByIdResponseDto.builder()
+				.battleId(battle.getId())
+				.isProgress(true)
+				.isVoted(false)
+				.battleGenre(GenreVoResponseDto.of(battle.getGenre()))
+				.challenging(
+					BattlePostInfoWithVoteCntResponseVo
+						.ofWithoutVoteCnt(challengingBattleInfo.getPost()))
+				.challenged(
+					BattlePostInfoWithVoteCntResponseVo
+						.ofWithoutVoteCnt(challengedBattleInfo.getPost()))
+				.build();
+
+		} else {
+			return BattleDetailByIdResponseDto.builder()
+				.battleId(battle.getId())
+				.isProgress(false)
+				.isVoted(false)
 				.battleGenre(GenreVoResponseDto.of(battle.getGenre()))
 				.challenging(
 					BattlePostInfoWithVoteCntResponseVo

--- a/src/main/java/com/example/demo/service/BattleService.java
+++ b/src/main/java/com/example/demo/service/BattleService.java
@@ -174,8 +174,8 @@ public class BattleService {
 		Battle battle = battleRepository.findById(battleId)
 			.orElseThrow(() -> new EntityNotFoundException(NOT_FOUND_BATTLE.getMessage()));
 		return voteRepository.existsByBattleAndVoter(battle, member)
-			? BattleDetailByIdResponseDto.of(battle, true)
-			: BattleDetailByIdResponseDto.of(battle, false);
+			? BattleDetailByIdResponseDto.ofVotedBattleDetail(battle)
+			: BattleDetailByIdResponseDto.ofNotVotedBattleDetail(battle);
 	}
 }
 

--- a/src/main/java/com/example/demo/service/BattleService.java
+++ b/src/main/java/com/example/demo/service/BattleService.java
@@ -6,7 +6,6 @@ import java.security.Principal;
 import java.text.MessageFormat;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 import javax.persistence.EntityNotFoundException;
 
@@ -170,11 +169,13 @@ public class BattleService {
 		return BattlesResponseDto.of(battles);
 	}
 
-	public BattleDetailByIdResponseDto getBattleDetailById(Long battleId) {
-		Optional<Battle> battle = battleRepository.findById(battleId);
-		return battle.map(BattleDetailByIdResponseDto::of).orElseThrow(
-			() -> new EntityNotFoundException(NOT_FOUND_BATTLE.getMessage())
-		);
+	public BattleDetailByIdResponseDto getBattleDetailById(Principal principal, Long battleId) {
+		Member member = principalService.getMemberByPrincipal(principal);
+		Battle battle = battleRepository.findById(battleId)
+			.orElseThrow(() -> new EntityNotFoundException(NOT_FOUND_BATTLE.getMessage()));
+		return voteRepository.existsByBattleAndVoter(battle, member)
+			? BattleDetailByIdResponseDto.of(battle, true)
+			: BattleDetailByIdResponseDto.of(battle, false);
 	}
 }
 

--- a/src/test/java/com/example/demo/controller/BattleControllerTest.java
+++ b/src/test/java/com/example/demo/controller/BattleControllerTest.java
@@ -857,7 +857,7 @@ class BattleControllerTest {
 									.description("대결 신청을 받은 게시물 대결 정보"),
 								fieldWithPath("data.challenged.postId").type(JsonFieldType.NUMBER)
 									.description("대결 신청을 받은 게시물 ID"),
-								fieldWithPath("data.challenged.voteCnt").type(NUMBER).optional()
+								fieldWithPath("data.challenged.voteCnt").type(JsonFieldType.NUMBER).optional()
 									.description("대결 신청 받은 게시물의 득표수 - optinal(isProgress가 true면 없음)"),
 								fieldWithPath("data.challenged.music").type(JsonFieldType.OBJECT)
 									.description("대결 신청을 받은 게시물에서 공유한 음악 정보"),
@@ -882,7 +882,7 @@ class BattleControllerTest {
 									.description("대결을 신청한 게시물 대결 정보"),
 								fieldWithPath("data.challenging.postId").type(JsonFieldType.NUMBER)
 									.description("대결을 신청한 게시물 ID"),
-								fieldWithPath("data.challenging.voteCnt").type(NUMBER).optional()
+								fieldWithPath("data.challenging.voteCnt").type(JsonFieldType.NUMBER).optional()
 									.description("대결을 신청한 게시물의 득표수 - optinal(isProgress가 true면 없음)"),
 								fieldWithPath("data.challenging.music").type(JsonFieldType.OBJECT)
 									.description("대결을 신청한 게시물에서 공유한 음악 정보"),

--- a/src/test/java/com/example/demo/controller/BattleControllerTest.java
+++ b/src/test/java/com/example/demo/controller/BattleControllerTest.java
@@ -823,7 +823,8 @@ class BattleControllerTest {
 			Long targetBattleId = battlesStatusIsProgress.get(0).getId();
 			//when
 			ResultActions resultActions = mockMvc
-				.perform(get("/api/v1/battles/{battleId}", targetBattleId));
+				.perform(get("/api/v1/battles/{battleId}", targetBattleId)
+					.header("Authorization", "Bearer accessToken"));
 			//then
 			resultActions.andExpect(status().isOk())
 				.andDo(print())
@@ -915,7 +916,8 @@ class BattleControllerTest {
 			Long targetBattleId = battlesStatusIsProgress.get(0).getId();
 			//when
 			ResultActions resultActions = mockMvc
-				.perform(get("/api/v1/battles/{battleId}", targetBattleId));
+				.perform(get("/api/v1/battles/{battleId}", targetBattleId)
+					.header("Authorization", "Bearer accessToken"));
 			//then
 			resultActions.andExpect(status().isOk())
 				.andDo(print())
@@ -1007,7 +1009,8 @@ class BattleControllerTest {
 			Long targetBattleId = 300L;
 			//when
 			ResultActions resultActions = mockMvc
-				.perform(get("/api/v1/battles/{battleId}", targetBattleId));
+				.perform(get("/api/v1/battles/{battleId}", targetBattleId)
+					.header("Authorization", "Bearer accessToken"));
 			//then
 			resultActions.andExpect(status().isNotFound())
 				.andDo(print())

--- a/src/test/java/com/example/demo/controller/BattleControllerTest.java
+++ b/src/test/java/com/example/demo/controller/BattleControllerTest.java
@@ -831,6 +831,9 @@ class BattleControllerTest {
 					resource(
 						ResourceSnippetParameters.builder()
 							.tag(BATTLE_API_NAME)
+							.requestHeaders(
+								headerWithName("Authorization").description("HYPE 서비스 access token")
+							)
 							.pathParameters(
 								parameterWithName("battleId").type(SimpleType.NUMBER)
 									.description("배틀id 입니다"))
@@ -843,6 +846,7 @@ class BattleControllerTest {
 									.description("API 요청 응답 데이터"),
 								fieldWithPath("data.battleId").type(JsonFieldType.NUMBER).description("대결 ID"),
 								fieldWithPath("data.isProgress").type(JsonFieldType.BOOLEAN).description("진행중인지 여부"),
+								fieldWithPath("data.isVoted").type(JsonFieldType.BOOLEAN).description("대결 투표 여부"),
 								fieldWithPath("data.battleGenre").type(JsonFieldType.OBJECT).description("대결의 장르"),
 								fieldWithPath("data.battleGenre.genreValue").type(JsonFieldType.STRING)
 									.description("대결의 장르 enum 값"),
@@ -919,6 +923,9 @@ class BattleControllerTest {
 					resource(
 						ResourceSnippetParameters.builder()
 							.tag(BATTLE_API_NAME)
+							.requestHeaders(
+								headerWithName("Authorization").description("HYPE 서비스 access token")
+							)
 							.pathParameters(
 								parameterWithName("battleId").type(SimpleType.NUMBER)
 									.description("배틀id 입니다"))
@@ -931,6 +938,7 @@ class BattleControllerTest {
 									.description("API 요청 응답 데이터"),
 								fieldWithPath("data.battleId").type(JsonFieldType.NUMBER).description("대결 ID"),
 								fieldWithPath("data.isProgress").type(JsonFieldType.BOOLEAN).description("진행중인지 여부"),
+								fieldWithPath("data.isVoted").type(JsonFieldType.BOOLEAN).description("대결 투표 여부"),
 								fieldWithPath("data.battleGenre").type(JsonFieldType.OBJECT).description("대결의 장르"),
 								fieldWithPath("data.battleGenre.genreValue").type(JsonFieldType.STRING)
 									.description("대결의 장르 enum 값"),
@@ -1007,6 +1015,9 @@ class BattleControllerTest {
 					resource(
 						ResourceSnippetParameters.builder()
 							.tag(BATTLE_API_NAME)
+							.requestHeaders(
+								headerWithName("Authorization").description("HYPE 서비스 access token")
+							)
 							.pathParameters(
 								parameterWithName("battleId").type(SimpleType.NUMBER)
 									.description("배틀id 입니다"))

--- a/src/test/java/com/example/demo/controller/member/MemberAllPostsRestDocsTest.java
+++ b/src/test/java/com/example/demo/controller/member/MemberAllPostsRestDocsTest.java
@@ -11,7 +11,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.security.Principal;
 import java.util.List;
-import java.util.Optional;
 
 import javax.persistence.EntityNotFoundException;
 
@@ -95,9 +94,9 @@ public class MemberAllPostsRestDocsTest {
 		// when
 		when(memberService.getAllPosts(
 			any(Principal.class),
-			any(Optional.class),
-			any(Optional.class),
-			any(Optional.class)))
+			any(),
+			any(),
+			any()))
 			.thenReturn(response);
 
 		var actions = mockMvc.perform(get("/api/v1/members/posts")
@@ -176,9 +175,9 @@ public class MemberAllPostsRestDocsTest {
 		// when
 		when(memberService.getAllPosts(
 			any(Principal.class),
-			any(Optional.class),
-			any(Optional.class),
-			any(Optional.class)))
+			any(),
+			any(),
+			any()))
 			.thenThrow(new EntityNotFoundException(ExceptionMessage.NOT_FOUND_MEMBER.getMessage()));
 		var actions = mockMvc.perform(get("/api/v1/members/posts")
 			.contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
## PR Description 🗒️

## 추가/변경 사항 및 설명 📝
- 대결 상세 페이지로 직접 접근 시 내가 이미 투표한 대결 상세인 경우 데이터 수정
  - 해당 게시글을 투표했는지 여부 반환 추가.

## To Reviewers 🙏
- 프론트와 얘기해보고 투표 수 반환은 FE, BE 추가적인 로직이 필요할 것 같아서 일단 투표 여부만 내려주기로 했습니다!!

## Issue close ✂️
closed #167 