### PR TITLE
[FIX] 유저 참여 대결 조회: index 초과 에러 해결

### DIFF
--- a/src/main/java/com/example/demo/service/MemberService.java
+++ b/src/main/java/com/example/demo/service/MemberService.java
@@ -186,7 +186,9 @@ public class MemberService {
 		}
 
 		if (Objects.nonNull(limit)) {
-			return new ArrayList<>(battles.subList(0, limit));
+			if (battles.size() > limit) {
+				return new ArrayList<>(battles.subList(0, limit));
+			}
 		}
 
 		return battles;


### PR DESCRIPTION
## PR Description 🗒️
유저 참여 대결 조회: index 초과 에러 해결

## 추가/변경 사항 및 설명 📝
limit이 들어올 때, 개수가 limit 개 미만일 때 범위 초과 오류가 나는 현상을 수정했습니다.

## Issue close ✂️
closed #170 