### PR TITLE
[FIX] 대결 상세조회 관련 로직 수정

### DIFF
--- a/src/main/java/com/example/demo/common/ExceptionMessage.java
+++ b/src/main/java/com/example/demo/common/ExceptionMessage.java
@@ -32,7 +32,10 @@ public enum ExceptionMessage {
 	CANNOT_ALL_REQUEST_FIELDS_NULL("적어도 하나의 필드(닉네임 또는 프로필 이미지 URL)를 제공해야합니다."),
 	CANNOT_NICKNAME_LENGTH_OVER_24("닉네임은 24자를 초과할 수 없습니다."),
 	NOT_EXIST_FILE_NAME("파일명이 존재하지 않습니다."),
-	CANNOT_NICKNAME_BLANK("닉네임은 공백만으로 이루어 질 수 없습니다.");
+	CANNOT_NICKNAME_BLANK("닉네임은 공백만으로 이루어 질 수 없습니다."),
+
+	//NumberFormatException
+	CANNOT_ACCESS_ANONYMOUS("로그인 하지 않은 사용자는 접근할 수 없습니다.");
 
 	final String message;
 

--- a/src/main/java/com/example/demo/controller/BattleController.java
+++ b/src/main/java/com/example/demo/controller/BattleController.java
@@ -78,8 +78,11 @@ public class BattleController {
 	}
 
 	@GetMapping("/{battleId}")
-	public ResponseEntity<ApiResponse> getBattleDetailByBattleId(@PathVariable Long battleId) {
-		BattleDetailByIdResponseDto battleDetailResponseDto = battleService.getBattleDetailById(battleId);
+	public ResponseEntity<ApiResponse> getBattleDetailByBattleId(
+		Principal principal,
+		@PathVariable Long battleId
+	) {
+		BattleDetailByIdResponseDto battleDetailResponseDto = battleService.getBattleDetailById(principal, battleId);
 		ApiResponse success = ApiResponse.success(SUCCESS_FIND_BATTLE_DETAIL_BY_ID.getMessage(),
 			battleDetailResponseDto);
 		return ResponseEntity.ok(success);

--- a/src/main/java/com/example/demo/controller/GlobalControllerAdvice.java
+++ b/src/main/java/com/example/demo/controller/GlobalControllerAdvice.java
@@ -4,12 +4,12 @@ import javax.persistence.EntityNotFoundException;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.example.demo.common.ApiResponse;
-import com.example.demo.common.ExceptionMessage;
 
 @RestControllerAdvice
 public class GlobalControllerAdvice {
@@ -38,9 +38,10 @@ public class GlobalControllerAdvice {
 		return new ResponseEntity<>(apiResponse, HttpStatus.UNAUTHORIZED);
 	}
 
-	@ExceptionHandler(NumberFormatException.class)
-	public ResponseEntity<ApiResponse> handleNumberFormatException(NumberFormatException exception) {
-		ApiResponse apiResponse = ApiResponse.fail(ExceptionMessage.CANNOT_ACCESS_ANONYMOUS.getMessage());
+	@ExceptionHandler(AuthenticationCredentialsNotFoundException.class)
+	public ResponseEntity<ApiResponse> handleAuthenticationCredentialsNotFoundException(
+		AuthenticationCredentialsNotFoundException exception) {
+		ApiResponse apiResponse = ApiResponse.fail(exception.getMessage());
 		return new ResponseEntity<>(apiResponse, HttpStatus.UNAUTHORIZED);
 	}
 }

--- a/src/main/java/com/example/demo/controller/GlobalControllerAdvice.java
+++ b/src/main/java/com/example/demo/controller/GlobalControllerAdvice.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.example.demo.common.ApiResponse;
+import com.example.demo.common.ExceptionMessage;
 
 @RestControllerAdvice
 public class GlobalControllerAdvice {
@@ -34,6 +35,12 @@ public class GlobalControllerAdvice {
 	@ExceptionHandler(OAuth2AuthenticationException.class)
 	public ResponseEntity<ApiResponse> handleOAuth2AuthenticationException(OAuth2AuthenticationException exception) {
 		ApiResponse apiResponse = ApiResponse.fail(exception.getMessage());
+		return new ResponseEntity<>(apiResponse, HttpStatus.UNAUTHORIZED);
+	}
+
+	@ExceptionHandler(NumberFormatException.class)
+	public ResponseEntity<ApiResponse> handleNumberFormatException(NumberFormatException exception) {
+		ApiResponse apiResponse = ApiResponse.fail(ExceptionMessage.CANNOT_ACCESS_ANONYMOUS.getMessage());
 		return new ResponseEntity<>(apiResponse, HttpStatus.UNAUTHORIZED);
 	}
 }

--- a/src/main/java/com/example/demo/dto/battle/BattleDetailByIdResponseDto.java
+++ b/src/main/java/com/example/demo/dto/battle/BattleDetailByIdResponseDto.java
@@ -12,53 +12,19 @@ import lombok.Builder;
 public record BattleDetailByIdResponseDto(
 	Long battleId,
 	boolean isProgress,
-	boolean isVoted,
+	Long selectedPostId,
 	GenreVoResponseDto battleGenre,
 	LocalDate battleCreatedDate,
 	BattlePostInfoWithVoteCntResponseVo challenged,
 	BattlePostInfoWithVoteCntResponseVo challenging
 ) {
-	public static BattleDetailByIdResponseDto ofVotedBattleDetail(Battle battle) {
+	public static BattleDetailByIdResponseDto ofNotVoted(Battle battle) {
 		BattleInfo challengedBattleInfo = battle.getChallengedPost();
 		BattleInfo challengingBattleInfo = battle.getChallengingPost();
 		if (battle.isProgress()) {
 			return BattleDetailByIdResponseDto.builder()
 				.battleId(battle.getId())
 				.isProgress(true)
-				.isVoted(true)
-				.battleGenre(GenreVoResponseDto.of(battle.getGenre()))
-				.battleCreatedDate(battle.getCreatedAt().toLocalDate())
-				.challenging(
-					BattlePostInfoWithVoteCntResponseVo.ofWithoutVoteCnt(challengingBattleInfo.getPost()))
-				.challenged(
-					BattlePostInfoWithVoteCntResponseVo.ofWithoutVoteCnt(challengedBattleInfo.getPost()))
-				.build();
-
-		} else {
-			return BattleDetailByIdResponseDto.builder()
-				.battleId(battle.getId())
-				.isProgress(false)
-				.isVoted(true)
-				.battleGenre(GenreVoResponseDto.of(battle.getGenre()))
-				.battleCreatedDate(battle.getCreatedAt().toLocalDate())
-				.challenging(
-					BattlePostInfoWithVoteCntResponseVo
-						.ofWithVoteCnt(challengingBattleInfo.getPost(), challengingBattleInfo.getVoteCount()))
-				.challenged(
-					BattlePostInfoWithVoteCntResponseVo
-						.ofWithVoteCnt(challengedBattleInfo.getPost(), challengedBattleInfo.getVoteCount()))
-				.build();
-		}
-	}
-
-	public static BattleDetailByIdResponseDto ofNotVotedBattleDetail(Battle battle) {
-		BattleInfo challengedBattleInfo = battle.getChallengedPost();
-		BattleInfo challengingBattleInfo = battle.getChallengingPost();
-		if (battle.isProgress()) {
-			return BattleDetailByIdResponseDto.builder()
-				.battleId(battle.getId())
-				.isProgress(true)
-				.isVoted(false)
 				.battleGenre(GenreVoResponseDto.of(battle.getGenre()))
 				.battleCreatedDate(battle.getCreatedAt().toLocalDate())
 				.challenging(
@@ -73,16 +39,35 @@ public record BattleDetailByIdResponseDto(
 			return BattleDetailByIdResponseDto.builder()
 				.battleId(battle.getId())
 				.isProgress(false)
-				.isVoted(false)
 				.battleGenre(GenreVoResponseDto.of(battle.getGenre()))
 				.battleCreatedDate(battle.getCreatedAt().toLocalDate())
 				.challenging(
-					BattlePostInfoWithVoteCntResponseVo.ofWithVoteCnt(challengingBattleInfo.getPost(),
-						challengingBattleInfo.getVoteCount()))
+					BattlePostInfoWithVoteCntResponseVo
+						.ofWithVoteCnt(challengingBattleInfo.getPost(), challengingBattleInfo.getVoteCount()))
 				.challenged(
-					BattlePostInfoWithVoteCntResponseVo.ofWithVoteCnt(challengedBattleInfo.getPost(),
-						challengedBattleInfo.getVoteCount()))
+					BattlePostInfoWithVoteCntResponseVo
+						.ofWithVoteCnt(challengedBattleInfo.getPost(), challengedBattleInfo.getVoteCount()))
 				.build();
 		}
 	}
+
+	public static BattleDetailByIdResponseDto ofVoted(Battle battle, Long selectedPostId) {
+		BattleInfo challengedBattleInfo = battle.getChallengedPost();
+		BattleInfo challengingBattleInfo = battle.getChallengingPost();
+		return BattleDetailByIdResponseDto.builder()
+			.battleId(battle.getId())
+			.isProgress(battle.isProgress())
+			.selectedPostId(selectedPostId)
+			.battleGenre(GenreVoResponseDto.of(battle.getGenre()))
+			.battleCreatedDate(battle.getCreatedAt().toLocalDate())
+			.challenging(
+				BattlePostInfoWithVoteCntResponseVo
+					.ofWithVoteCnt(challengingBattleInfo.getPost(), challengingBattleInfo.getVoteCount()))
+			.challenged(
+				BattlePostInfoWithVoteCntResponseVo
+					.ofWithVoteCnt(challengedBattleInfo.getPost(), challengedBattleInfo.getVoteCount()))
+			.build();
+
+	}
+
 }

--- a/src/main/java/com/example/demo/dto/battle/BattleDetailByIdResponseDto.java
+++ b/src/main/java/com/example/demo/dto/battle/BattleDetailByIdResponseDto.java
@@ -1,6 +1,5 @@
 package com.example.demo.dto.battle;
 
-
 import java.time.LocalDate;
 
 import com.example.demo.dto.genre.GenreVoResponseDto;
@@ -41,6 +40,7 @@ public record BattleDetailByIdResponseDto(
 				.isProgress(false)
 				.isVoted(true)
 				.battleGenre(GenreVoResponseDto.of(battle.getGenre()))
+				.battleCreatedDate(battle.getCreatedAt().toLocalDate())
 				.challenging(
 					BattlePostInfoWithVoteCntResponseVo
 						.ofWithVoteCnt(challengingBattleInfo.getPost(), challengingBattleInfo.getVoteCount()))
@@ -60,6 +60,7 @@ public record BattleDetailByIdResponseDto(
 				.isProgress(true)
 				.isVoted(false)
 				.battleGenre(GenreVoResponseDto.of(battle.getGenre()))
+				.battleCreatedDate(battle.getCreatedAt().toLocalDate())
 				.challenging(
 					BattlePostInfoWithVoteCntResponseVo
 						.ofWithoutVoteCnt(challengingBattleInfo.getPost()))

--- a/src/main/java/com/example/demo/dto/battle/BattleDetailByIdResponseDto.java
+++ b/src/main/java/com/example/demo/dto/battle/BattleDetailByIdResponseDto.java
@@ -10,17 +10,19 @@ import lombok.Builder;
 public record BattleDetailByIdResponseDto(
 	Long battleId,
 	boolean isProgress,
+	boolean isVoted,
 	GenreVoResponseDto battleGenre,
 	BattlePostInfoWithVoteCntResponseVo challenged,
 	BattlePostInfoWithVoteCntResponseVo challenging
 ) {
-	public static BattleDetailByIdResponseDto of(Battle battle) {
+	public static BattleDetailByIdResponseDto of(Battle battle, boolean isVoted) {
 		BattleInfo challengedBattleInfo = battle.getChallengedPost();
 		BattleInfo challengingBattleInfo = battle.getChallengingPost();
 		if (battle.isProgress()) {
 			return BattleDetailByIdResponseDto.builder()
 				.battleId(battle.getId())
 				.isProgress(true)
+				.isVoted(isVoted)
 				.battleGenre(GenreVoResponseDto.of(battle.getGenre()))
 				.challenging(
 					BattlePostInfoWithVoteCntResponseVo
@@ -34,6 +36,7 @@ public record BattleDetailByIdResponseDto(
 			return BattleDetailByIdResponseDto.builder()
 				.battleId(battle.getId())
 				.isProgress(false)
+				.isVoted(isVoted)
 				.battleGenre(GenreVoResponseDto.of(battle.getGenre()))
 				.challenging(
 					BattlePostInfoWithVoteCntResponseVo

--- a/src/main/java/com/example/demo/dto/battle/BattleDetailByIdResponseDto.java
+++ b/src/main/java/com/example/demo/dto/battle/BattleDetailByIdResponseDto.java
@@ -15,14 +15,14 @@ public record BattleDetailByIdResponseDto(
 	BattlePostInfoWithVoteCntResponseVo challenged,
 	BattlePostInfoWithVoteCntResponseVo challenging
 ) {
-	public static BattleDetailByIdResponseDto of(Battle battle, boolean isVoted) {
+	public static BattleDetailByIdResponseDto ofVotedBattleDetail(Battle battle) {
 		BattleInfo challengedBattleInfo = battle.getChallengedPost();
 		BattleInfo challengingBattleInfo = battle.getChallengingPost();
 		if (battle.isProgress()) {
 			return BattleDetailByIdResponseDto.builder()
 				.battleId(battle.getId())
 				.isProgress(true)
-				.isVoted(isVoted)
+				.isVoted(true)
 				.battleGenre(GenreVoResponseDto.of(battle.getGenre()))
 				.challenging(
 					BattlePostInfoWithVoteCntResponseVo
@@ -36,7 +36,40 @@ public record BattleDetailByIdResponseDto(
 			return BattleDetailByIdResponseDto.builder()
 				.battleId(battle.getId())
 				.isProgress(false)
-				.isVoted(isVoted)
+				.isVoted(true)
+				.battleGenre(GenreVoResponseDto.of(battle.getGenre()))
+				.challenging(
+					BattlePostInfoWithVoteCntResponseVo
+						.ofWithVoteCnt(challengingBattleInfo.getPost(), challengingBattleInfo.getVoteCount()))
+				.challenged(
+					BattlePostInfoWithVoteCntResponseVo
+						.ofWithVoteCnt(challengedBattleInfo.getPost(), challengedBattleInfo.getVoteCount()))
+				.build();
+		}
+	}
+
+	public static BattleDetailByIdResponseDto ofNotVotedBattleDetail(Battle battle) {
+		BattleInfo challengedBattleInfo = battle.getChallengedPost();
+		BattleInfo challengingBattleInfo = battle.getChallengingPost();
+		if (battle.isProgress()) {
+			return BattleDetailByIdResponseDto.builder()
+				.battleId(battle.getId())
+				.isProgress(true)
+				.isVoted(false)
+				.battleGenre(GenreVoResponseDto.of(battle.getGenre()))
+				.challenging(
+					BattlePostInfoWithVoteCntResponseVo
+						.ofWithoutVoteCnt(challengingBattleInfo.getPost()))
+				.challenged(
+					BattlePostInfoWithVoteCntResponseVo
+						.ofWithoutVoteCnt(challengedBattleInfo.getPost()))
+				.build();
+
+		} else {
+			return BattleDetailByIdResponseDto.builder()
+				.battleId(battle.getId())
+				.isProgress(false)
+				.isVoted(false)
 				.battleGenre(GenreVoResponseDto.of(battle.getGenre()))
 				.challenging(
 					BattlePostInfoWithVoteCntResponseVo

--- a/src/main/java/com/example/demo/repository/VoteRepository.java
+++ b/src/main/java/com/example/demo/repository/VoteRepository.java
@@ -1,6 +1,7 @@
 package com.example.demo.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -11,6 +12,8 @@ import com.example.demo.model.member.Member;
 public interface VoteRepository extends JpaRepository<Vote, Long> {
 
 	List<Vote> findAllByVoterId(Long voterId);
+
+	Optional<Vote> findByBattleAndVoter(Battle battle, Member voter);
 
 	boolean existsByBattleAndVoter(Battle battle, Member voter);
 }

--- a/src/main/java/com/example/demo/service/BattleService.java
+++ b/src/main/java/com/example/demo/service/BattleService.java
@@ -174,8 +174,8 @@ public class BattleService {
 		Battle battle = battleRepository.findById(battleId)
 			.orElseThrow(() -> new EntityNotFoundException(NOT_FOUND_BATTLE.getMessage()));
 		return voteRepository.existsByBattleAndVoter(battle, member)
-			? BattleDetailByIdResponseDto.of(battle, true)
-			: BattleDetailByIdResponseDto.of(battle, false);
+			? BattleDetailByIdResponseDto.ofVotedBattleDetail(battle)
+			: BattleDetailByIdResponseDto.ofNotVotedBattleDetail(battle);
 	}
 }
 

--- a/src/main/java/com/example/demo/service/BattleService.java
+++ b/src/main/java/com/example/demo/service/BattleService.java
@@ -6,6 +6,7 @@ import java.security.Principal;
 import java.text.MessageFormat;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 
 import javax.persistence.EntityNotFoundException;
 
@@ -173,9 +174,16 @@ public class BattleService {
 		Member member = principalService.getMemberByPrincipal(principal);
 		Battle battle = battleRepository.findById(battleId)
 			.orElseThrow(() -> new EntityNotFoundException(NOT_FOUND_BATTLE.getMessage()));
-		return voteRepository.existsByBattleAndVoter(battle, member)
-			? BattleDetailByIdResponseDto.ofVotedBattleDetail(battle)
-			: BattleDetailByIdResponseDto.ofNotVotedBattleDetail(battle);
+		Long selectedPostId = voteRepository.findByBattleAndVoter(battle, member)//투표한 적 있다면?
+			.map(element -> element.getSelectedPost().getId())
+			.orElse(null);
+		if (Objects.isNull(selectedPostId)) {
+			//투표를 안했다
+			return BattleDetailByIdResponseDto.ofNotVoted(battle);
+		} else {
+			//투표를 했다.
+			return BattleDetailByIdResponseDto.ofVoted(battle, selectedPostId);
+		}
 	}
 }
 

--- a/src/main/java/com/example/demo/service/BattleService.java
+++ b/src/main/java/com/example/demo/service/BattleService.java
@@ -6,7 +6,7 @@ import java.security.Principal;
 import java.text.MessageFormat;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Objects;
+import java.util.Optional;
 
 import javax.persistence.EntityNotFoundException;
 
@@ -174,15 +174,15 @@ public class BattleService {
 		Member member = principalService.getMemberByPrincipal(principal);
 		Battle battle = battleRepository.findById(battleId)
 			.orElseThrow(() -> new EntityNotFoundException(NOT_FOUND_BATTLE.getMessage()));
-		Long selectedPostId = voteRepository.findByBattleAndVoter(battle, member)//투표한 적 있다면?
-			.map(element -> element.getSelectedPost().getId())
-			.orElse(null);
-		if (Objects.isNull(selectedPostId)) {
+		Optional<Long> selectedPostId = voteRepository.findByBattleAndVoter(battle, member)//투표한 적 있다면?
+			.map(element -> Optional.of(element.getSelectedPost().getId()))
+			.orElse(Optional.empty());
+		if (selectedPostId.isEmpty()) {
 			//투표를 안했다
 			return BattleDetailByIdResponseDto.ofNotVoted(battle);
 		} else {
 			//투표를 했다.
-			return BattleDetailByIdResponseDto.ofVoted(battle, selectedPostId);
+			return BattleDetailByIdResponseDto.ofVoted(battle, selectedPostId.get());
 		}
 	}
 }

--- a/src/main/java/com/example/demo/service/BattleService.java
+++ b/src/main/java/com/example/demo/service/BattleService.java
@@ -6,7 +6,6 @@ import java.security.Principal;
 import java.text.MessageFormat;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 import javax.persistence.EntityNotFoundException;
 
@@ -170,11 +169,13 @@ public class BattleService {
 		return BattlesResponseDto.of(battles);
 	}
 
-	public BattleDetailByIdResponseDto getBattleDetailById(Long battleId) {
-		Optional<Battle> battle = battleRepository.findById(battleId);
-		return battle.map(BattleDetailByIdResponseDto::of).orElseThrow(
-			() -> new EntityNotFoundException(NOT_FOUND_BATTLE.getMessage())
-		);
+	public BattleDetailByIdResponseDto getBattleDetailById(Principal principal, Long battleId) {
+		Member member = principalService.getMemberByPrincipal(principal);
+		Battle battle = battleRepository.findById(battleId)
+			.orElseThrow(() -> new EntityNotFoundException(NOT_FOUND_BATTLE.getMessage()));
+		return voteRepository.existsByBattleAndVoter(battle, member)
+			? BattleDetailByIdResponseDto.of(battle, true)
+			: BattleDetailByIdResponseDto.of(battle, false);
 	}
 }
 

--- a/src/main/java/com/example/demo/service/PrincipalService.java
+++ b/src/main/java/com/example/demo/service/PrincipalService.java
@@ -4,6 +4,7 @@ import java.security.Principal;
 
 import javax.persistence.EntityNotFoundException;
 
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.stereotype.Service;
 
 import com.example.demo.common.ExceptionMessage;
@@ -19,7 +20,13 @@ public class PrincipalService {
 	private final MemberRepository memberRepository;
 
 	public Member getMemberByPrincipal(Principal principal) {
-		return memberRepository.findById(Long.valueOf(principal.getName()))
-			.orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.NOT_FOUND_MEMBER.getMessage()));
+		try {
+			Long id = Long.valueOf(principal.getName());
+			return memberRepository.findById(id)
+				.orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.NOT_FOUND_MEMBER.getMessage()));
+		} catch (NumberFormatException | NullPointerException exception) {
+			throw new AuthenticationCredentialsNotFoundException(ExceptionMessage.CANNOT_ACCESS_ANONYMOUS.getMessage());
+		}
+
 	}
 }

--- a/src/test/java/com/example/demo/controller/BattleControllerTest.java
+++ b/src/test/java/com/example/demo/controller/BattleControllerTest.java
@@ -816,98 +816,98 @@ class BattleControllerTest {
 	@Nested
 	@WithMockUser(username = "1")
 	class GetBattleDetailById {
-		@Test
-		public void 성공_given_끝나지않은_battleId_then_배틀의_상세정보_200() throws Exception {
-			//given
-			List<Battle> battlesStatusIsProgress = battleRepository.findAllByStatusEquals(BattleStatus.PROGRESS);
-			Long targetBattleId = battlesStatusIsProgress.get(0).getId();
-			//when
-			ResultActions resultActions = mockMvc
-				.perform(get("/api/v1/battles/{battleId}", targetBattleId)
-					.header("Authorization", "Bearer accessToken"));
-			//then
-			resultActions.andExpect(status().isOk())
-				.andDo(print())
-				.andDo(document("not-ended-battle-detail",
-					resource(
-						ResourceSnippetParameters.builder()
-							.tag(BATTLE_API_NAME)
-							.requestHeaders(
-								headerWithName("Authorization").description("HYPE 서비스 access token")
-							)
-							.pathParameters(
-								parameterWithName("battleId").type(SimpleType.NUMBER)
-									.description("대결 ID"))
-							.responseFields(
-								fieldWithPath("success").type(JsonFieldType.BOOLEAN)
-									.description("API 요청 성공 여부"),
-								fieldWithPath("message").type(JsonFieldType.STRING)
-									.description("API 요청 응답 메시지"),
-								fieldWithPath("data").type(JsonFieldType.OBJECT)
-									.description("API 요청 응답 데이터"),
-								fieldWithPath("data.battleId").type(JsonFieldType.NUMBER).description("대결 ID"),
-								fieldWithPath("data.isProgress").type(JsonFieldType.BOOLEAN).description("진행중인지 여부"),
-								fieldWithPath("data.isVoted").type(JsonFieldType.BOOLEAN).description("대결 투표 여부"),
-								fieldWithPath("data.battleGenre").type(JsonFieldType.OBJECT).description("대결의 장르"),
-								fieldWithPath("data.battleGenre.genreValue").type(JsonFieldType.STRING)
-									.description("대결의 장르 enum 값"),
-								fieldWithPath("data.battleGenre.genreName").type(JsonFieldType.STRING)
-									.description("대결의 장르명"),
-								fieldWithPath("data.challenged").type(JsonFieldType.OBJECT)
-									.description("대결 신청을 받은 게시물 대결 정보"),
-								fieldWithPath("data.challenged.postId").type(JsonFieldType.NUMBER)
-									.description("대결 신청을 받은 게시물 ID"),
-								fieldWithPath("data.challenged.voteCnt").type(JsonFieldType.NUMBER).optional()
-									.description("대결 신청 받은 게시물의 득표수 - optinal(isProgress가 true면 없음)"),
-								fieldWithPath("data.challenged.music").type(JsonFieldType.OBJECT)
-									.description("대결 신청을 받은 게시물에서 공유한 음악 정보"),
-								fieldWithPath("data.challenged.music.musicId").type(JsonFieldType.STRING)
-									.description("대결 신청을 받은 게시물에서 공유한 음악의 고유 번호"),
-								fieldWithPath("data.challenged.music.singer").type(JsonFieldType.STRING)
-									.description("대결 신청을 받은 게시물에서 공유한 음악의 가수명"),
-								fieldWithPath("data.challenged.music.title").type(JsonFieldType.STRING)
-									.description("대결 신청을 받은 게시물에서 공유한 음악의 제목"),
-								fieldWithPath("data.challenged.music.genre").type(JsonFieldType.OBJECT)
-									.description("대결 신청을 받은 게시물에서 공유한 음악의 장르"),
-								fieldWithPath("data.challenged.music.genre.genreValue").type(JsonFieldType.STRING)
-									.description("대결 신청을 받은 게시물에서 공유한 음악의 장르 enum 값"),
-								fieldWithPath("data.challenged.music.genre.genreName").type(JsonFieldType.STRING)
-									.description("대결 신청을 받은 게시물에서 공유한 음악의 장르명"),
-								fieldWithPath("data.challenged.music.musicUrl").type(JsonFieldType.STRING)
-									.description("대결 신청을 받은 게시물에서 공유한 음악의 재생 URL"),
-								fieldWithPath("data.challenged.music.albumCoverUrl").type(JsonFieldType.STRING)
-									.description("대결 신청을 받은 게시물에서 공유한 음악의 앨범 커버 URL"),
-
-								fieldWithPath("data.challenging").type(JsonFieldType.OBJECT)
-									.description("대결을 신청한 게시물 대결 정보"),
-								fieldWithPath("data.challenging.postId").type(JsonFieldType.NUMBER)
-									.description("대결을 신청한 게시물 ID"),
-								fieldWithPath("data.challenging.voteCnt").type(JsonFieldType.NUMBER).optional()
-									.description("대결을 신청한 게시물의 득표수 - optinal(isProgress가 true면 없음)"),
-								fieldWithPath("data.challenging.music").type(JsonFieldType.OBJECT)
-									.description("대결을 신청한 게시물에서 공유한 음악 정보"),
-								fieldWithPath("data.challenging.music.musicId").type(JsonFieldType.STRING)
-									.description("대결을 신청한 게시물에서 공유한 음악의 고유 번호"),
-								fieldWithPath("data.challenging.music.singer").type(JsonFieldType.STRING)
-									.description("대결을 신청한 게시물에서 공유한 음악의 가수명"),
-								fieldWithPath("data.challenging.music.title").type(JsonFieldType.STRING)
-									.description("대결을 신청한 게시물에서 공유한 음악의 제목"),
-								fieldWithPath("data.challenging.music.genre").type(JsonFieldType.OBJECT)
-									.description("대결을 신청한 게시물에서 공유한 음악의 장르"),
-								fieldWithPath("data.challenging.music.genre.genreValue").type(JsonFieldType.STRING)
-									.description("대결을 신청한 게시물에서 공유한 음악의 장르 enum 값"),
-								fieldWithPath("data.challenging.music.genre.genreName").type(JsonFieldType.STRING)
-									.description("대결을 신청한 게시물에서 공유한 음악의 장르명"),
-								fieldWithPath("data.challenging.music.musicUrl").type(JsonFieldType.STRING)
-									.description("대결을 신청한 게시물에서 공유한 음악의 재생 URL"),
-								fieldWithPath("data.challenging.music.albumCoverUrl").type(JsonFieldType.STRING)
-									.description("대결을 신청한 게시물에서 공유한 음악의 앨범 커버 URL")
-
-							)
-							.build()
-					)
-				));
-		}
+		// @Test
+		// public void 성공_given_끝나지않은_battleId_then_배틀의_상세정보_200() throws Exception {
+		// 	//given
+		// 	List<Battle> battlesStatusIsProgress = battleRepository.findAllByStatusEquals(BattleStatus.PROGRESS);
+		// 	Long targetBattleId = battlesStatusIsProgress.get(0).getId();
+		// 	//when
+		// 	ResultActions resultActions = mockMvc
+		// 		.perform(get("/api/v1/battles/{battleId}", targetBattleId)
+		// 			.header("Authorization", "Bearer accessToken"));
+		// 	//then
+		// 	resultActions.andExpect(status().isOk())
+		// 		.andDo(print())
+		// 		.andDo(document("not-ended-battle-detail",
+		// 			resource(
+		// 				ResourceSnippetParameters.builder()
+		// 					.tag(BATTLE_API_NAME)
+		// 					.requestHeaders(
+		// 						headerWithName("Authorization").description("HYPE 서비스 access token")
+		// 					)
+		// 					.pathParameters(
+		// 						parameterWithName("battleId").type(SimpleType.NUMBER)
+		// 							.description("대결 ID"))
+		// 					.responseFields(
+		// 						fieldWithPath("success").type(JsonFieldType.BOOLEAN)
+		// 							.description("API 요청 성공 여부"),
+		// 						fieldWithPath("message").type(JsonFieldType.STRING)
+		// 							.description("API 요청 응답 메시지"),
+		// 						fieldWithPath("data").type(JsonFieldType.OBJECT)
+		// 							.description("API 요청 응답 데이터"),
+		// 						fieldWithPath("data.battleId").type(JsonFieldType.NUMBER).description("대결 ID"),
+		// 						fieldWithPath("data.isProgress").type(JsonFieldType.BOOLEAN).description("진행중인지 여부"),
+		// 						fieldWithPath("data.isVoted").type(JsonFieldType.BOOLEAN).description("대결 투표 여부"),
+		// 						fieldWithPath("data.battleGenre").type(JsonFieldType.OBJECT).description("대결의 장르"),
+		// 						fieldWithPath("data.battleGenre.genreValue").type(JsonFieldType.STRING)
+		// 							.description("대결의 장르 enum 값"),
+		// 						fieldWithPath("data.battleGenre.genreName").type(JsonFieldType.STRING)
+		// 							.description("대결의 장르명"),
+		// 						fieldWithPath("data.challenged").type(JsonFieldType.OBJECT)
+		// 							.description("대결 신청을 받은 게시물 대결 정보"),
+		// 						fieldWithPath("data.challenged.postId").type(JsonFieldType.NUMBER)
+		// 							.description("대결 신청을 받은 게시물 ID"),
+		// 						fieldWithPath("data.challenged.voteCnt").type(JsonFieldType.NUMBER).optional()
+		// 							.description("대결 신청 받은 게시물의 득표수 - optinal(isProgress가 true면 없음)"),
+		// 						fieldWithPath("data.challenged.music").type(JsonFieldType.OBJECT)
+		// 							.description("대결 신청을 받은 게시물에서 공유한 음악 정보"),
+		// 						fieldWithPath("data.challenged.music.musicId").type(JsonFieldType.STRING)
+		// 							.description("대결 신청을 받은 게시물에서 공유한 음악의 고유 번호"),
+		// 						fieldWithPath("data.challenged.music.singer").type(JsonFieldType.STRING)
+		// 							.description("대결 신청을 받은 게시물에서 공유한 음악의 가수명"),
+		// 						fieldWithPath("data.challenged.music.title").type(JsonFieldType.STRING)
+		// 							.description("대결 신청을 받은 게시물에서 공유한 음악의 제목"),
+		// 						fieldWithPath("data.challenged.music.genre").type(JsonFieldType.OBJECT)
+		// 							.description("대결 신청을 받은 게시물에서 공유한 음악의 장르"),
+		// 						fieldWithPath("data.challenged.music.genre.genreValue").type(JsonFieldType.STRING)
+		// 							.description("대결 신청을 받은 게시물에서 공유한 음악의 장르 enum 값"),
+		// 						fieldWithPath("data.challenged.music.genre.genreName").type(JsonFieldType.STRING)
+		// 							.description("대결 신청을 받은 게시물에서 공유한 음악의 장르명"),
+		// 						fieldWithPath("data.challenged.music.musicUrl").type(JsonFieldType.STRING)
+		// 							.description("대결 신청을 받은 게시물에서 공유한 음악의 재생 URL"),
+		// 						fieldWithPath("data.challenged.music.albumCoverUrl").type(JsonFieldType.STRING)
+		// 							.description("대결 신청을 받은 게시물에서 공유한 음악의 앨범 커버 URL"),
+		//
+		// 						fieldWithPath("data.challenging").type(JsonFieldType.OBJECT)
+		// 							.description("대결을 신청한 게시물 대결 정보"),
+		// 						fieldWithPath("data.challenging.postId").type(JsonFieldType.NUMBER)
+		// 							.description("대결을 신청한 게시물 ID"),
+		// 						fieldWithPath("data.challenging.voteCnt").type(JsonFieldType.NUMBER).optional()
+		// 							.description("대결을 신청한 게시물의 득표수 - optinal(isProgress가 true면 없음)"),
+		// 						fieldWithPath("data.challenging.music").type(JsonFieldType.OBJECT)
+		// 							.description("대결을 신청한 게시물에서 공유한 음악 정보"),
+		// 						fieldWithPath("data.challenging.music.musicId").type(JsonFieldType.STRING)
+		// 							.description("대결을 신청한 게시물에서 공유한 음악의 고유 번호"),
+		// 						fieldWithPath("data.challenging.music.singer").type(JsonFieldType.STRING)
+		// 							.description("대결을 신청한 게시물에서 공유한 음악의 가수명"),
+		// 						fieldWithPath("data.challenging.music.title").type(JsonFieldType.STRING)
+		// 							.description("대결을 신청한 게시물에서 공유한 음악의 제목"),
+		// 						fieldWithPath("data.challenging.music.genre").type(JsonFieldType.OBJECT)
+		// 							.description("대결을 신청한 게시물에서 공유한 음악의 장르"),
+		// 						fieldWithPath("data.challenging.music.genre.genreValue").type(JsonFieldType.STRING)
+		// 							.description("대결을 신청한 게시물에서 공유한 음악의 장르 enum 값"),
+		// 						fieldWithPath("data.challenging.music.genre.genreName").type(JsonFieldType.STRING)
+		// 							.description("대결을 신청한 게시물에서 공유한 음악의 장르명"),
+		// 						fieldWithPath("data.challenging.music.musicUrl").type(JsonFieldType.STRING)
+		// 							.description("대결을 신청한 게시물에서 공유한 음악의 재생 URL"),
+		// 						fieldWithPath("data.challenging.music.albumCoverUrl").type(JsonFieldType.STRING)
+		// 							.description("대결을 신청한 게시물에서 공유한 음악의 앨범 커버 URL")
+		//
+		// 					)
+		// 					.build()
+		// 			)
+		// 		));
+		// }
 
 		@Test
 		public void 성공_given_이미끝난_battleId_then_그_배틀의_상세정보_및_투표수_200() throws Exception {

--- a/src/test/java/com/example/demo/controller/BattleControllerTest.java
+++ b/src/test/java/com/example/demo/controller/BattleControllerTest.java
@@ -847,7 +847,7 @@ class BattleControllerTest {
 									.description("API 요청 응답 데이터"),
 								fieldWithPath("data.battleId").type(JsonFieldType.NUMBER).description("대결 ID"),
 								fieldWithPath("data.isProgress").type(JsonFieldType.BOOLEAN).description("진행중인지 여부"),
-								fieldWithPath("data.isVoted").type(JsonFieldType.STRING).description("대결 투표 여부"),
+								fieldWithPath("data.isVoted").type(JsonFieldType.BOOLEAN).description("대결 투표 여부"),
 								fieldWithPath("data.battleGenre").type(JsonFieldType.OBJECT).description("대결의 장르"),
 								fieldWithPath("data.battleGenre.genreValue").type(JsonFieldType.STRING)
 									.description("대결의 장르 enum 값"),

--- a/src/test/java/com/example/demo/controller/BattleControllerTest.java
+++ b/src/test/java/com/example/demo/controller/BattleControllerTest.java
@@ -837,7 +837,8 @@ class BattleControllerTest {
 							)
 							.pathParameters(
 								parameterWithName("battleId").type(SimpleType.NUMBER)
-									.description("대결 ID"))
+									.description("대결 ID")
+							)
 							.responseFields(
 								fieldWithPath("success").type(JsonFieldType.BOOLEAN)
 									.description("API 요청 성공 여부"),
@@ -853,6 +854,9 @@ class BattleControllerTest {
 									.description("대결의 장르 enum 값"),
 								fieldWithPath("data.battleGenre.genreName").type(JsonFieldType.STRING)
 									.description("대결의 장르명"),
+								fieldWithPath("data.battleCreatedDate").type(JsonFieldType.STRING)
+									.description("배틀이 생성된 날짜"),
+
 								fieldWithPath("data.challenged").type(JsonFieldType.OBJECT)
 									.description("대결 신청을 받은 게시물 대결 정보"),
 								fieldWithPath("data.challenged.postId").type(JsonFieldType.NUMBER)
@@ -877,6 +881,12 @@ class BattleControllerTest {
 									.description("대결 신청을 받은 게시물에서 공유한 음악의 재생 URL"),
 								fieldWithPath("data.challenged.music.albumCoverUrl").type(JsonFieldType.STRING)
 									.description("대결 신청을 받은 게시물에서 공유한 음악의 앨범 커버 URL"),
+								fieldWithPath("data.challenged.postWriter").type(OBJECT)
+									.description("challenged post 작성 멤버"),
+								fieldWithPath("data.challenged.postWriter.memberId").type(NUMBER)
+									.description("challenged post 작성 멤버 id"),
+								fieldWithPath("data.challenged.postWriter.nickname").type(JsonFieldType.STRING)
+									.description("challenged post 작성 멤버 nickname"),
 
 								fieldWithPath("data.challenging").type(JsonFieldType.OBJECT)
 									.description("대결을 신청한 게시물 대결 정보"),
@@ -901,7 +911,13 @@ class BattleControllerTest {
 								fieldWithPath("data.challenging.music.musicUrl").type(JsonFieldType.STRING)
 									.description("대결을 신청한 게시물에서 공유한 음악의 재생 URL"),
 								fieldWithPath("data.challenging.music.albumCoverUrl").type(JsonFieldType.STRING)
-									.description("대결을 신청한 게시물에서 공유한 음악의 앨범 커버 URL")
+									.description("대결을 신청한 게시물에서 공유한 음악의 앨범 커버 URL"),
+								fieldWithPath("data.challenging.postWriter").type(OBJECT)
+									.description("challenged post 작성 멤버"),
+								fieldWithPath("data.challenging.postWriter.memberId").type(NUMBER)
+									.description("challenged post 작성 멤버 id"),
+								fieldWithPath("data.challenging.postWriter.nickname").type(JsonFieldType.STRING)
+									.description("challenged post 작성 멤버 nickname")
 
 							)
 							.build()

--- a/src/test/java/com/example/demo/controller/BattleControllerTest.java
+++ b/src/test/java/com/example/demo/controller/BattleControllerTest.java
@@ -817,7 +817,7 @@ class BattleControllerTest {
 	@WithMockUser(username = "1")
 	class GetBattleDetailById {
 		@Test
-		public void 성공_given_끝나지않은_battleId_then_그_배틀의_상세정보_200() throws Exception {
+		public void 성공_given_끝나지않은_battleId_then_배틀의_상세정보_200() throws Exception {
 			//given
 			List<Battle> battlesStatusIsProgress = battleRepository.findAllByStatusEquals(BattleStatus.PROGRESS);
 			Long targetBattleId = battlesStatusIsProgress.get(0).getId();
@@ -837,7 +837,7 @@ class BattleControllerTest {
 							)
 							.pathParameters(
 								parameterWithName("battleId").type(SimpleType.NUMBER)
-									.description("배틀id 입니다"))
+									.description("대결 ID"))
 							.responseFields(
 								fieldWithPath("success").type(JsonFieldType.BOOLEAN)
 									.description("API 요청 성공 여부"),
@@ -847,7 +847,7 @@ class BattleControllerTest {
 									.description("API 요청 응답 데이터"),
 								fieldWithPath("data.battleId").type(JsonFieldType.NUMBER).description("대결 ID"),
 								fieldWithPath("data.isProgress").type(JsonFieldType.BOOLEAN).description("진행중인지 여부"),
-								fieldWithPath("data.isVoted").type(JsonFieldType.BOOLEAN).description("대결 투표 여부"),
+								fieldWithPath("data.isVoted").type(JsonFieldType.STRING).description("대결 투표 여부"),
 								fieldWithPath("data.battleGenre").type(JsonFieldType.OBJECT).description("대결의 장르"),
 								fieldWithPath("data.battleGenre.genreValue").type(JsonFieldType.STRING)
 									.description("대결의 장르 enum 값"),

--- a/src/test/java/com/example/demo/controller/BattleControllerTest.java
+++ b/src/test/java/com/example/demo/controller/BattleControllerTest.java
@@ -857,7 +857,7 @@ class BattleControllerTest {
 									.description("대결 신청을 받은 게시물 대결 정보"),
 								fieldWithPath("data.challenged.postId").type(JsonFieldType.NUMBER)
 									.description("대결 신청을 받은 게시물 ID"),
-								fieldWithPath("data.challenged.voteCnt").type(NUMBER).optional()
+								fieldWithPath("data.challenged.voteCnt").type(JsonFieldType.NUMBER).optional()
 									.description("대결 신청 받은 게시물의 득표수 - optinal(isProgress가 true면 없음)"),
 								fieldWithPath("data.challenged.music").type(JsonFieldType.OBJECT)
 									.description("대결 신청을 받은 게시물에서 공유한 음악 정보"),
@@ -882,7 +882,7 @@ class BattleControllerTest {
 									.description("대결을 신청한 게시물 대결 정보"),
 								fieldWithPath("data.challenging.postId").type(JsonFieldType.NUMBER)
 									.description("대결을 신청한 게시물 ID"),
-								fieldWithPath("data.challenging.voteCnt").type(NUMBER).optional()
+								fieldWithPath("data.challenging.voteCnt").type(JsonFieldType.NUMBER).optional()
 									.description("대결을 신청한 게시물의 득표수 - optinal(isProgress가 true면 없음)"),
 								fieldWithPath("data.challenging.music").type(JsonFieldType.OBJECT)
 									.description("대결을 신청한 게시물에서 공유한 음악 정보"),

--- a/src/test/java/com/example/demo/controller/BattleControllerTest.java
+++ b/src/test/java/com/example/demo/controller/BattleControllerTest.java
@@ -930,7 +930,7 @@ class BattleControllerTest {
 							)
 							.pathParameters(
 								parameterWithName("battleId").type(SimpleType.NUMBER)
-									.description("배틀id 입니다"))
+									.description("대결 ID"))
 							.responseFields(
 								fieldWithPath("success").type(JsonFieldType.BOOLEAN)
 									.description("API 요청 성공 여부"),

--- a/src/test/java/com/example/demo/controller/BattleControllerTest.java
+++ b/src/test/java/com/example/demo/controller/BattleControllerTest.java
@@ -816,98 +816,98 @@ class BattleControllerTest {
 	@Nested
 	@WithMockUser(username = "1")
 	class GetBattleDetailById {
-		// @Test
-		// public void 성공_given_끝나지않은_battleId_then_배틀의_상세정보_200() throws Exception {
-		// 	//given
-		// 	List<Battle> battlesStatusIsProgress = battleRepository.findAllByStatusEquals(BattleStatus.PROGRESS);
-		// 	Long targetBattleId = battlesStatusIsProgress.get(0).getId();
-		// 	//when
-		// 	ResultActions resultActions = mockMvc
-		// 		.perform(get("/api/v1/battles/{battleId}", targetBattleId)
-		// 			.header("Authorization", "Bearer accessToken"));
-		// 	//then
-		// 	resultActions.andExpect(status().isOk())
-		// 		.andDo(print())
-		// 		.andDo(document("not-ended-battle-detail",
-		// 			resource(
-		// 				ResourceSnippetParameters.builder()
-		// 					.tag(BATTLE_API_NAME)
-		// 					.requestHeaders(
-		// 						headerWithName("Authorization").description("HYPE 서비스 access token")
-		// 					)
-		// 					.pathParameters(
-		// 						parameterWithName("battleId").type(SimpleType.NUMBER)
-		// 							.description("대결 ID"))
-		// 					.responseFields(
-		// 						fieldWithPath("success").type(JsonFieldType.BOOLEAN)
-		// 							.description("API 요청 성공 여부"),
-		// 						fieldWithPath("message").type(JsonFieldType.STRING)
-		// 							.description("API 요청 응답 메시지"),
-		// 						fieldWithPath("data").type(JsonFieldType.OBJECT)
-		// 							.description("API 요청 응답 데이터"),
-		// 						fieldWithPath("data.battleId").type(JsonFieldType.NUMBER).description("대결 ID"),
-		// 						fieldWithPath("data.isProgress").type(JsonFieldType.BOOLEAN).description("진행중인지 여부"),
-		// 						fieldWithPath("data.isVoted").type(JsonFieldType.BOOLEAN).description("대결 투표 여부"),
-		// 						fieldWithPath("data.battleGenre").type(JsonFieldType.OBJECT).description("대결의 장르"),
-		// 						fieldWithPath("data.battleGenre.genreValue").type(JsonFieldType.STRING)
-		// 							.description("대결의 장르 enum 값"),
-		// 						fieldWithPath("data.battleGenre.genreName").type(JsonFieldType.STRING)
-		// 							.description("대결의 장르명"),
-		// 						fieldWithPath("data.challenged").type(JsonFieldType.OBJECT)
-		// 							.description("대결 신청을 받은 게시물 대결 정보"),
-		// 						fieldWithPath("data.challenged.postId").type(JsonFieldType.NUMBER)
-		// 							.description("대결 신청을 받은 게시물 ID"),
-		// 						fieldWithPath("data.challenged.voteCnt").type(JsonFieldType.NUMBER).optional()
-		// 							.description("대결 신청 받은 게시물의 득표수 - optinal(isProgress가 true면 없음)"),
-		// 						fieldWithPath("data.challenged.music").type(JsonFieldType.OBJECT)
-		// 							.description("대결 신청을 받은 게시물에서 공유한 음악 정보"),
-		// 						fieldWithPath("data.challenged.music.musicId").type(JsonFieldType.STRING)
-		// 							.description("대결 신청을 받은 게시물에서 공유한 음악의 고유 번호"),
-		// 						fieldWithPath("data.challenged.music.singer").type(JsonFieldType.STRING)
-		// 							.description("대결 신청을 받은 게시물에서 공유한 음악의 가수명"),
-		// 						fieldWithPath("data.challenged.music.title").type(JsonFieldType.STRING)
-		// 							.description("대결 신청을 받은 게시물에서 공유한 음악의 제목"),
-		// 						fieldWithPath("data.challenged.music.genre").type(JsonFieldType.OBJECT)
-		// 							.description("대결 신청을 받은 게시물에서 공유한 음악의 장르"),
-		// 						fieldWithPath("data.challenged.music.genre.genreValue").type(JsonFieldType.STRING)
-		// 							.description("대결 신청을 받은 게시물에서 공유한 음악의 장르 enum 값"),
-		// 						fieldWithPath("data.challenged.music.genre.genreName").type(JsonFieldType.STRING)
-		// 							.description("대결 신청을 받은 게시물에서 공유한 음악의 장르명"),
-		// 						fieldWithPath("data.challenged.music.musicUrl").type(JsonFieldType.STRING)
-		// 							.description("대결 신청을 받은 게시물에서 공유한 음악의 재생 URL"),
-		// 						fieldWithPath("data.challenged.music.albumCoverUrl").type(JsonFieldType.STRING)
-		// 							.description("대결 신청을 받은 게시물에서 공유한 음악의 앨범 커버 URL"),
-		//
-		// 						fieldWithPath("data.challenging").type(JsonFieldType.OBJECT)
-		// 							.description("대결을 신청한 게시물 대결 정보"),
-		// 						fieldWithPath("data.challenging.postId").type(JsonFieldType.NUMBER)
-		// 							.description("대결을 신청한 게시물 ID"),
-		// 						fieldWithPath("data.challenging.voteCnt").type(JsonFieldType.NUMBER).optional()
-		// 							.description("대결을 신청한 게시물의 득표수 - optinal(isProgress가 true면 없음)"),
-		// 						fieldWithPath("data.challenging.music").type(JsonFieldType.OBJECT)
-		// 							.description("대결을 신청한 게시물에서 공유한 음악 정보"),
-		// 						fieldWithPath("data.challenging.music.musicId").type(JsonFieldType.STRING)
-		// 							.description("대결을 신청한 게시물에서 공유한 음악의 고유 번호"),
-		// 						fieldWithPath("data.challenging.music.singer").type(JsonFieldType.STRING)
-		// 							.description("대결을 신청한 게시물에서 공유한 음악의 가수명"),
-		// 						fieldWithPath("data.challenging.music.title").type(JsonFieldType.STRING)
-		// 							.description("대결을 신청한 게시물에서 공유한 음악의 제목"),
-		// 						fieldWithPath("data.challenging.music.genre").type(JsonFieldType.OBJECT)
-		// 							.description("대결을 신청한 게시물에서 공유한 음악의 장르"),
-		// 						fieldWithPath("data.challenging.music.genre.genreValue").type(JsonFieldType.STRING)
-		// 							.description("대결을 신청한 게시물에서 공유한 음악의 장르 enum 값"),
-		// 						fieldWithPath("data.challenging.music.genre.genreName").type(JsonFieldType.STRING)
-		// 							.description("대결을 신청한 게시물에서 공유한 음악의 장르명"),
-		// 						fieldWithPath("data.challenging.music.musicUrl").type(JsonFieldType.STRING)
-		// 							.description("대결을 신청한 게시물에서 공유한 음악의 재생 URL"),
-		// 						fieldWithPath("data.challenging.music.albumCoverUrl").type(JsonFieldType.STRING)
-		// 							.description("대결을 신청한 게시물에서 공유한 음악의 앨범 커버 URL")
-		//
-		// 					)
-		// 					.build()
-		// 			)
-		// 		));
-		// }
+		@Test
+		public void 성공_given_끝나지않은_battleId_then_배틀의_상세정보_200() throws Exception {
+			//given
+			List<Battle> battlesStatusIsProgress = battleRepository.findAllByStatusEquals(BattleStatus.PROGRESS);
+			Long targetBattleId = battlesStatusIsProgress.get(0).getId();
+			//when
+			ResultActions resultActions = mockMvc
+				.perform(get("/api/v1/battles/{battleId}", targetBattleId)
+					.header("Authorization", "Bearer accessToken"));
+			//then
+			resultActions.andExpect(status().isOk())
+				.andDo(print())
+				.andDo(document("not-ended-battle-detail",
+					resource(
+						ResourceSnippetParameters.builder()
+							.tag(BATTLE_API_NAME)
+							.requestHeaders(
+								headerWithName("Authorization").description("HYPE 서비스 access token")
+							)
+							.pathParameters(
+								parameterWithName("battleId").type(SimpleType.NUMBER)
+									.description("대결 ID"))
+							.responseFields(
+								fieldWithPath("success").type(JsonFieldType.BOOLEAN)
+									.description("API 요청 성공 여부"),
+								fieldWithPath("message").type(JsonFieldType.STRING)
+									.description("API 요청 응답 메시지"),
+								fieldWithPath("data").type(JsonFieldType.OBJECT)
+									.description("API 요청 응답 데이터"),
+								fieldWithPath("data.battleId").type(JsonFieldType.NUMBER).description("대결 ID"),
+								fieldWithPath("data.isProgress").type(JsonFieldType.BOOLEAN).description("진행중인지 여부"),
+								fieldWithPath("data.isVoted").type(JsonFieldType.BOOLEAN).description("대결 투표 여부"),
+								fieldWithPath("data.battleGenre").type(JsonFieldType.OBJECT).description("대결의 장르"),
+								fieldWithPath("data.battleGenre.genreValue").type(JsonFieldType.STRING)
+									.description("대결의 장르 enum 값"),
+								fieldWithPath("data.battleGenre.genreName").type(JsonFieldType.STRING)
+									.description("대결의 장르명"),
+								fieldWithPath("data.challenged").type(JsonFieldType.OBJECT)
+									.description("대결 신청을 받은 게시물 대결 정보"),
+								fieldWithPath("data.challenged.postId").type(JsonFieldType.NUMBER)
+									.description("대결 신청을 받은 게시물 ID"),
+								fieldWithPath("data.challenged.voteCnt").type(JsonFieldType.NUMBER).optional()
+									.description("대결 신청 받은 게시물의 득표수 - optinal(isProgress가 true면 없음)"),
+								fieldWithPath("data.challenged.music").type(JsonFieldType.OBJECT)
+									.description("대결 신청을 받은 게시물에서 공유한 음악 정보"),
+								fieldWithPath("data.challenged.music.musicId").type(JsonFieldType.STRING)
+									.description("대결 신청을 받은 게시물에서 공유한 음악의 고유 번호"),
+								fieldWithPath("data.challenged.music.singer").type(JsonFieldType.STRING)
+									.description("대결 신청을 받은 게시물에서 공유한 음악의 가수명"),
+								fieldWithPath("data.challenged.music.title").type(JsonFieldType.STRING)
+									.description("대결 신청을 받은 게시물에서 공유한 음악의 제목"),
+								fieldWithPath("data.challenged.music.genre").type(JsonFieldType.OBJECT)
+									.description("대결 신청을 받은 게시물에서 공유한 음악의 장르"),
+								fieldWithPath("data.challenged.music.genre.genreValue").type(JsonFieldType.STRING)
+									.description("대결 신청을 받은 게시물에서 공유한 음악의 장르 enum 값"),
+								fieldWithPath("data.challenged.music.genre.genreName").type(JsonFieldType.STRING)
+									.description("대결 신청을 받은 게시물에서 공유한 음악의 장르명"),
+								fieldWithPath("data.challenged.music.musicUrl").type(JsonFieldType.STRING)
+									.description("대결 신청을 받은 게시물에서 공유한 음악의 재생 URL"),
+								fieldWithPath("data.challenged.music.albumCoverUrl").type(JsonFieldType.STRING)
+									.description("대결 신청을 받은 게시물에서 공유한 음악의 앨범 커버 URL"),
+
+								fieldWithPath("data.challenging").type(JsonFieldType.OBJECT)
+									.description("대결을 신청한 게시물 대결 정보"),
+								fieldWithPath("data.challenging.postId").type(JsonFieldType.NUMBER)
+									.description("대결을 신청한 게시물 ID"),
+								fieldWithPath("data.challenging.voteCnt").type(JsonFieldType.NUMBER).optional()
+									.description("대결을 신청한 게시물의 득표수 - optinal(isProgress가 true면 없음)"),
+								fieldWithPath("data.challenging.music").type(JsonFieldType.OBJECT)
+									.description("대결을 신청한 게시물에서 공유한 음악 정보"),
+								fieldWithPath("data.challenging.music.musicId").type(JsonFieldType.STRING)
+									.description("대결을 신청한 게시물에서 공유한 음악의 고유 번호"),
+								fieldWithPath("data.challenging.music.singer").type(JsonFieldType.STRING)
+									.description("대결을 신청한 게시물에서 공유한 음악의 가수명"),
+								fieldWithPath("data.challenging.music.title").type(JsonFieldType.STRING)
+									.description("대결을 신청한 게시물에서 공유한 음악의 제목"),
+								fieldWithPath("data.challenging.music.genre").type(JsonFieldType.OBJECT)
+									.description("대결을 신청한 게시물에서 공유한 음악의 장르"),
+								fieldWithPath("data.challenging.music.genre.genreValue").type(JsonFieldType.STRING)
+									.description("대결을 신청한 게시물에서 공유한 음악의 장르 enum 값"),
+								fieldWithPath("data.challenging.music.genre.genreName").type(JsonFieldType.STRING)
+									.description("대결을 신청한 게시물에서 공유한 음악의 장르명"),
+								fieldWithPath("data.challenging.music.musicUrl").type(JsonFieldType.STRING)
+									.description("대결을 신청한 게시물에서 공유한 음악의 재생 URL"),
+								fieldWithPath("data.challenging.music.albumCoverUrl").type(JsonFieldType.STRING)
+									.description("대결을 신청한 게시물에서 공유한 음악의 앨범 커버 URL")
+
+							)
+							.build()
+					)
+				));
+		}
 
 		@Test
 		public void 성공_given_이미끝난_battleId_then_그_배틀의_상세정보_및_투표수_200() throws Exception {

--- a/src/test/java/com/example/demo/controller/BattleControllerTest.java
+++ b/src/test/java/com/example/demo/controller/BattleControllerTest.java
@@ -823,7 +823,8 @@ class BattleControllerTest {
 			Long targetBattleId = battlesStatusIsProgress.get(0).getId();
 			//when
 			ResultActions resultActions = mockMvc
-				.perform(get("/api/v1/battles/{battleId}", targetBattleId));
+				.perform(get("/api/v1/battles/{battleId}", targetBattleId)
+					.header("Authorization", "Bearer accessToken"));
 			//then
 			resultActions.andExpect(status().isOk())
 				.andDo(print())
@@ -915,7 +916,8 @@ class BattleControllerTest {
 			Long targetBattleId = battlesStatusIsProgress.get(0).getId();
 			//when
 			ResultActions resultActions = mockMvc
-				.perform(get("/api/v1/battles/{battleId}", targetBattleId));
+				.perform(get("/api/v1/battles/{battleId}", targetBattleId)
+					.header("Authorization", "Bearer accessToken"));
 			//then
 			resultActions.andExpect(status().isOk())
 				.andDo(print())
@@ -1007,7 +1009,8 @@ class BattleControllerTest {
 			Long targetBattleId = 300L;
 			//when
 			ResultActions resultActions = mockMvc
-				.perform(get("/api/v1/battles/{battleId}", targetBattleId));
+				.perform(get("/api/v1/battles/{battleId}", targetBattleId)
+					.header("Authorization", "Bearer accessToken"));
 			//then
 			resultActions.andExpect(status().isNotFound())
 				.andDo(print())

--- a/src/test/java/com/example/demo/controller/BattleControllerTest.java
+++ b/src/test/java/com/example/demo/controller/BattleControllerTest.java
@@ -831,6 +831,9 @@ class BattleControllerTest {
 					resource(
 						ResourceSnippetParameters.builder()
 							.tag(BATTLE_API_NAME)
+							.requestHeaders(
+								headerWithName("Authorization").description("HYPE 서비스 access token")
+							)
 							.pathParameters(
 								parameterWithName("battleId").type(SimpleType.NUMBER)
 									.description("배틀id 입니다"))
@@ -843,6 +846,7 @@ class BattleControllerTest {
 									.description("API 요청 응답 데이터"),
 								fieldWithPath("data.battleId").type(JsonFieldType.NUMBER).description("대결 ID"),
 								fieldWithPath("data.isProgress").type(JsonFieldType.BOOLEAN).description("진행중인지 여부"),
+								fieldWithPath("data.isVoted").type(JsonFieldType.BOOLEAN).description("대결 투표 여부"),
 								fieldWithPath("data.battleGenre").type(JsonFieldType.OBJECT).description("대결의 장르"),
 								fieldWithPath("data.battleGenre.genreValue").type(JsonFieldType.STRING)
 									.description("대결의 장르 enum 값"),
@@ -919,6 +923,9 @@ class BattleControllerTest {
 					resource(
 						ResourceSnippetParameters.builder()
 							.tag(BATTLE_API_NAME)
+							.requestHeaders(
+								headerWithName("Authorization").description("HYPE 서비스 access token")
+							)
 							.pathParameters(
 								parameterWithName("battleId").type(SimpleType.NUMBER)
 									.description("배틀id 입니다"))
@@ -931,6 +938,7 @@ class BattleControllerTest {
 									.description("API 요청 응답 데이터"),
 								fieldWithPath("data.battleId").type(JsonFieldType.NUMBER).description("대결 ID"),
 								fieldWithPath("data.isProgress").type(JsonFieldType.BOOLEAN).description("진행중인지 여부"),
+								fieldWithPath("data.isVoted").type(JsonFieldType.BOOLEAN).description("대결 투표 여부"),
 								fieldWithPath("data.battleGenre").type(JsonFieldType.OBJECT).description("대결의 장르"),
 								fieldWithPath("data.battleGenre.genreValue").type(JsonFieldType.STRING)
 									.description("대결의 장르 enum 값"),
@@ -1007,6 +1015,9 @@ class BattleControllerTest {
 					resource(
 						ResourceSnippetParameters.builder()
 							.tag(BATTLE_API_NAME)
+							.requestHeaders(
+								headerWithName("Authorization").description("HYPE 서비스 access token")
+							)
 							.pathParameters(
 								parameterWithName("battleId").type(SimpleType.NUMBER)
 									.description("배틀id 입니다"))

--- a/src/test/java/com/example/demo/controller/member/MemberAllPostsRestDocsTest.java
+++ b/src/test/java/com/example/demo/controller/member/MemberAllPostsRestDocsTest.java
@@ -11,7 +11,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.security.Principal;
 import java.util.List;
-import java.util.Optional;
 
 import javax.persistence.EntityNotFoundException;
 
@@ -95,9 +94,9 @@ public class MemberAllPostsRestDocsTest {
 		// when
 		when(memberService.getAllPosts(
 			any(Principal.class),
-			any(Optional.class),
-			any(Optional.class),
-			any(Optional.class)))
+			any(),
+			any(),
+			any()))
 			.thenReturn(response);
 
 		var actions = mockMvc.perform(get("/api/v1/members/posts")
@@ -176,9 +175,9 @@ public class MemberAllPostsRestDocsTest {
 		// when
 		when(memberService.getAllPosts(
 			any(Principal.class),
-			any(Optional.class),
-			any(Optional.class),
-			any(Optional.class)))
+			any(),
+			any(),
+			any()))
 			.thenThrow(new EntityNotFoundException(ExceptionMessage.NOT_FOUND_MEMBER.getMessage()));
 		var actions = mockMvc.perform(get("/api/v1/members/posts")
 			.contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
## PR Description 🗒️

## 추가/변경 사항 및 설명 📝
- 대결 상세 페이지로 직접 접근 시 내가 이미 투표한 대결 상세인 경우 데이터 수정
  - 해당 게시글을 투표했는지 여부 반환 추가.

## To Reviewers 🙏
- 프론트와 얘기해보고 투표 수 반환은 FE, BE 추가적인 로직이 필요할 것 같아서 일단 투표 여부만 내려주기로 했습니다!!
- 로컬에서는 build가 실패하지 않고 실제 데이터가 문서화와 타입이 다르지도 않은데 ci 실패가 떠서 다시 PR 보내봅니다,,,

## Issue close ✂️
closed #167 