### PR TITLE
[FIX] 스케줄러 변경: 승리포인트 업데이트 비활성화

### DIFF
--- a/src/main/java/com/example/demo/controller/SchedulerController.java
+++ b/src/main/java/com/example/demo/controller/SchedulerController.java
@@ -20,7 +20,7 @@ public class SchedulerController {
 
 	private final int rankingTerm = 7;
 
-	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+	@Scheduled(cron = "0 0 1 * * *", zone = "Asia/Seoul")
 	@Transactional
 	public void updateBattleResult() {
 		battleService.quitBattles();

--- a/src/main/java/com/example/demo/controller/SchedulerController.java
+++ b/src/main/java/com/example/demo/controller/SchedulerController.java
@@ -2,6 +2,7 @@ package com.example.demo.controller;
 
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.demo.service.BattleService;
@@ -17,9 +18,10 @@ public class SchedulerController {
 	private final BattleService battleService;
 	private final MemberService memberService;
 
-	private final int rankingTerm = 1;
+	private final int rankingTerm = 7;
 
 	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+	@Transactional
 	public void updateBattleResult() {
 		battleService.quitBattles();
 		memberService.resetAllRankingAndPoint();

--- a/src/main/java/com/example/demo/service/BattleService.java
+++ b/src/main/java/com/example/demo/service/BattleService.java
@@ -129,9 +129,9 @@ public class BattleService {
 		return battleRepository.findByStatusAndCreatedAtIsBefore(BattleStatus.PROGRESS, endDate);
 	}
 
-	private List<Battle> findBattlesEndWithinPerm(int perm) {
+	private List<Battle> findBattlesEndWithinPerm(int term) {
 		LocalDateTime now = LocalDateTime.now();
-		LocalDateTime lastBattleDay = now.minusDays(perm - 1);
+		LocalDateTime lastBattleDay = now.minusDays(term);
 		return battleRepository.findByStatusAndUpdatedAtBetween(BattleStatus.END, lastBattleDay, now);
 	}
 


### PR DESCRIPTION
## PR Description 🗒️
[FIX] 스케줄러 변경: 승리포인트 업데이트 비활성화

## 추가/변경 사항 및 설명 📝
- 변수명 변경
- 시간 변경
- transactional 변경
- 산정 범위 하루에서 일주일로 확장

## To Reviewers 🙏
급한 사항이라 리뷰 없이 바로 붙일게요,,

## Issue close ✂️
closed #178 