### PR TITLE
[FEAT] 메인 페이지 랜덤한 배틀 정보 조회 기능

### DIFF
--- a/src/main/java/com/example/demo/common/ExceptionMessage.java
+++ b/src/main/java/com/example/demo/common/ExceptionMessage.java
@@ -24,6 +24,7 @@ public enum ExceptionMessage {
 	CANNOT_MAKE_BATTLE_SAME_MUSIC("두 Post가 같은 음악에 대한 Post입니다."),
 	CANNOT_MAKE_BATTLE_ALREADY_EXIST_PROGRESS_BATTLE("해당 post들에 대한 진행중인 battle이 이미 존재합니다."),
 	NOT_ALLOWED_FILE_FORMAT("허용되지 않는 파일 형식입니다."),
+	NOT_PROGRESS_BATTLE("진행중인 배틀이 없습니다."),
 
 	// IllegalStateException
 	FAIL_UPLOAD_FILE_S3("저장소에 파일 업로드가 실패했습니다."),

--- a/src/main/java/com/example/demo/common/ResponseMessage.java
+++ b/src/main/java/com/example/demo/common/ResponseMessage.java
@@ -9,21 +9,22 @@ public enum ResponseMessage {
 	SUCCESS_MY_PAGE_PROFILE("마이페이지 상세정보 조회 성공"),
 	SUCCESS_USER_PAGE_PROFILE("유저페이지 상세정보 조회 성공"),
 	SUCCESS_USER_UPDATE("유저 프로필 정보 수정 성공"),
-	SUCCESS_USER_LIKE_POSTS("유저 좋아요한 게시글 리스트 조회 성공"),
+	SUCCESS_USER_LIKE_POSTS("유저가 좋아요한 게시글 리스트 조회 성공"),
 	SUCCESS_FIND_RANKERS("랭커 리스트 조회 성공"),
 	// Post
-	SUCCESS_CREATE_POST("음악 공유 게시글 등록 성공"),
-	SUCCESS_FIND_ALL_POST("음악 공유 게시글 리스트 조회 성공"),
-	SUCCESS_FIND_POST("음악 공유 게시글 상세 조회 성공"),
+	SUCCESS_CREATE_POST("음악 추천 게시글 등록 성공"),
+	SUCCESS_FIND_ALL_POST("음악 추천 게시글 리스트 조회 성공"),
+	SUCCESS_FIND_POST("음악 추천 게시글 상세 조회 성공"),
+	SUCCESS_LIKE_POST("추천글 좋아요 성공"),
+	SUCCESS_UNLIKE_POST("추천글 좋아요 해제 성공"),
 	// Battle
 	SUCCESS_FIND_ALL_CANDIDATE_POST("대결곡 후보 게시글 리스트 조회 성공"),
 	SUCCESS_FIND_ALL_BATTLE_DETAILS("대결 상세 정보 리스트 조회 성공"),
 	SUCCESS_VOTE("대결 투표 성공"),
-	SUCCESS_CREATE_BATTLE("배틀 등록 성공"),
+	SUCCESS_CREATE_BATTLE("대결 등록 성공"),
 	SUCCESS_FIND_BATTLES("대결 리스트 조회 성공"),
-	SUCCESS_FIND_BATTLE_DETAIL_BY_ID("배틀 상세 조회 성공"),
-	SUCCESS_LIKE_POST("추천글 좋아요 성공"),
-	SUCCESS_UNLIKE_POST("추천글 좋아요 해제 성공");
+	SUCCESS_FIND_BATTLE_DETAIL_BY_ID("대결 상세 조회 성공"),
+	SUCCESS_RANDOM_BATTLE("랜덤한 대결 상세 조회 성공");
 
 	final String message;
 

--- a/src/main/java/com/example/demo/common/ResponseMessage.java
+++ b/src/main/java/com/example/demo/common/ResponseMessage.java
@@ -24,9 +24,7 @@ public enum ResponseMessage {
 	SUCCESS_CREATE_BATTLE("대결 등록 성공"),
 	SUCCESS_FIND_BATTLES("대결 리스트 조회 성공"),
 	SUCCESS_FIND_BATTLE_DETAIL_BY_ID("배틀 상세 조회 성공"),
-  SUCCESS_RANDOM_BATTLE("랜덤한 대결 상세 조회 성공"),
-	SUCCESS_LIKE_POST("추천글 좋아요 성공"),
-	SUCCESS_UNLIKE_POST("추천글 좋아요 해제 성공"),
+	SUCCESS_RANDOM_BATTLE("랜덤한 대결 상세 조회 성공"),
 	SUCCESS_GET_IS_LIKE("좋아요 여부 판단 성공");
 
 	final String message;

--- a/src/main/java/com/example/demo/controller/BattleController.java
+++ b/src/main/java/com/example/demo/controller/BattleController.java
@@ -23,6 +23,7 @@ import com.example.demo.common.ResponseMessage;
 import com.example.demo.dto.battle.BattleCreateRequestDto;
 import com.example.demo.dto.battle.BattleDetailByIdResponseDto;
 import com.example.demo.dto.battle.BattleDetailsListResponseDto;
+import com.example.demo.dto.battle.BattleDetailsResponseDto;
 import com.example.demo.dto.battle.BattlesResponseDto;
 import com.example.demo.dto.vote.BattleVoteRequestDto;
 import com.example.demo.dto.vote.VoteResultResponseDto;
@@ -111,6 +112,16 @@ public class BattleController {
 		return ResponseEntity.ok(
 			ApiResponse.success(
 				ResponseMessage.SUCCESS_FIND_ALL_BATTLE_DETAILS.getMessage(),
+				responseDto
+			));
+	}
+
+	@GetMapping("/random")
+	public ResponseEntity<ApiResponse> getRandomBattle() {
+		BattleDetailsResponseDto responseDto = battleService.getRandomBattleDetail();
+		return ResponseEntity.ok(
+			ApiResponse.success(
+				ResponseMessage.SUCCESS_RANDOM_BATTLE.getMessage(),
 				responseDto
 			));
 	}

--- a/src/main/java/com/example/demo/repository/BattleRepository.java
+++ b/src/main/java/com/example/demo/repository/BattleRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 
 import javax.persistence.LockModeType;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -35,4 +36,8 @@ public interface BattleRepository extends JpaRepository<Battle, Long> {
 	boolean existsByChallengedPost_PostAndChallengingPost_PostAndStatus(
 		Post challengedPost, Post challengingPost, BattleStatus battleStatus
 	);
+
+	@Query("SELECT b FROM Battle b WHERE b.id >= :id and b.status = :status ORDER BY b.id asc")
+	List<Battle> findRandomBattle(
+		@Param("id") Long id, @Param("status") BattleStatus status, Pageable pageable);
 }

--- a/src/main/java/com/example/demo/service/BattleService.java
+++ b/src/main/java/com/example/demo/service/BattleService.java
@@ -7,15 +7,18 @@ import java.text.MessageFormat;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Random;
 
 import javax.persistence.EntityNotFoundException;
 
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.demo.dto.battle.BattleCreateRequestDto;
 import com.example.demo.dto.battle.BattleDetailByIdResponseDto;
 import com.example.demo.dto.battle.BattleDetailsListResponseDto;
+import com.example.demo.dto.battle.BattleDetailsResponseDto;
 import com.example.demo.dto.battle.BattlesResponseDto;
 import com.example.demo.model.battle.Battle;
 import com.example.demo.model.battle.BattleStatus;
@@ -206,6 +209,18 @@ public class BattleService {
 			//투표를 했다.
 			return BattleDetailByIdResponseDto.ofVoted(battle, selectedPostId.get());
 		}
+	}
+
+	public BattleDetailsResponseDto getRandomBattleDetail() {
+		long count = battleRepository.count();
+		long randomIndex = new Random().nextInt((int)count) + 1;
+		List<Battle> randomBattle = battleRepository.findRandomBattle(randomIndex, BattleStatus.PROGRESS,
+			PageRequest.of(0, 1));
+
+		if (randomBattle.size() < 1) {
+			throw new IllegalArgumentException(NOT_PROGRESS_BATTLE.getMessage());
+		}
+		return BattleDetailsResponseDto.of(randomBattle.get(0));
 	}
 }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
     port: 6379
   profiles:
     active:
-      - test
+      - local
   security:
     oauth2:
       client:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
     port: 6379
   profiles:
     active:
-      - local
+      - test
   security:
     oauth2:
       client:

--- a/src/test/java/com/example/demo/controller/battle/BattleRamdomTest.java
+++ b/src/test/java/com/example/demo/controller/battle/BattleRamdomTest.java
@@ -1,0 +1,122 @@
+package com.example.demo.controller.battle;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.example.demo.common.ApiResponse;
+import com.example.demo.controller.BattleController;
+import com.example.demo.model.battle.Battle;
+import com.example.demo.model.battle.BattleStatus;
+import com.example.demo.model.member.Member;
+import com.example.demo.model.member.Social;
+import com.example.demo.model.post.Genre;
+import com.example.demo.model.post.Music;
+import com.example.demo.model.post.Post;
+import com.example.demo.repository.BattleRepository;
+import com.example.demo.repository.MemberRepository;
+import com.example.demo.repository.PostRepository;
+import com.example.demo.repository.VoteRepository;
+import com.example.demo.service.BattleService;
+import com.example.demo.service.PrincipalService;
+import com.example.demo.service.VoteService;
+
+@DataJpaTest
+class BattleRamdomTest {
+
+	@Autowired
+	MemberRepository memberRepository;
+
+	@Autowired
+	PostRepository postRepository;
+
+	@Autowired
+	BattleRepository battleRepository;
+
+	BattleService battleService;
+	BattleController battleController;
+
+	@BeforeEach
+	void setup() {
+		battleService = new BattleService(mock(PrincipalService.class), battleRepository, mock(VoteRepository.class),
+			postRepository);
+		battleController = new BattleController(mock(PrincipalService.class), mock(VoteService.class), battleService);
+	}
+
+	@Test
+	void 성공_무작위로_진행중인_대결_상세정보를_조회할_수_있다() {
+		// given
+		Member member = createMember();
+		Member challenger = createMember();
+		createBattleList(member, challenger);
+
+		// when
+		ResponseEntity<ApiResponse> response = battleController.getRandomBattle();
+
+		// then
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody().data()).isNotNull();
+	}
+
+	private void createBattleList(Member member, Member challenger) {
+		Genre genre = Genre.INDIE_ACOUSTIC;
+		int loop = 5;
+		for (int i = 0; i < loop; i++) {
+			Post challengedPost = createPost(member, createMusic(String.format("ABCD12%s", i), genre));
+			Post challengingPost = createPost(challenger, createMusic(String.format("ABCD17%s", i), genre));
+			Battle battle = createBattle(genre, challengedPost, challengingPost);
+		}
+	}
+
+	private Member createMember() {
+		Member member = Member.builder()
+			.nickname("nickname")
+			.socialId("socialId")
+			.refreshToken("refreshToken")
+			.socialType(Social.GOOGLE)
+			.profileImageUrl("profileImageUrl")
+			.build();
+		memberRepository.save(member);
+		return member;
+	}
+
+	private Music createMusic(String musicId, Genre genre) {
+		return new Music(
+			musicId,
+			"albumCoverUrl",
+			"singer",
+			"title",
+			genre,
+			"musicUrl"
+		);
+	}
+
+	private Post createPost(Member member, Music music) {
+		Post post = new Post(
+			music,
+			"content",
+			true,
+			0,
+			member
+		);
+		postRepository.save(post);
+		return post;
+	}
+
+	private Battle createBattle(Genre genre, Post challenged, Post challenging) {
+		Battle battle = new Battle(
+			genre,
+			BattleStatus.PROGRESS,
+			challenged,
+			challenging
+		);
+		battleRepository.save(battle);
+		return battle;
+	}
+}

--- a/src/test/java/com/example/demo/controller/battle/BattleRandomRestDocsTest.java
+++ b/src/test/java/com/example/demo/controller/battle/BattleRandomRestDocsTest.java
@@ -1,0 +1,191 @@
+package com.example.demo.controller.battle;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.example.demo.common.ExceptionMessage;
+import com.example.demo.controller.BattleController;
+import com.example.demo.dto.battle.BattleDetailsResponseDto;
+import com.example.demo.dto.battle.BattlePostResponseVo;
+import com.example.demo.dto.common.MusicVoResponseDto;
+import com.example.demo.dto.genre.GenreVoResponseDto;
+import com.example.demo.model.post.Genre;
+import com.example.demo.model.post.Music;
+import com.example.demo.security.TokenAuthenticationFilter;
+import com.example.demo.service.BattleService;
+import com.example.demo.service.PrincipalService;
+import com.example.demo.service.VoteService;
+
+@WithMockUser
+@ExtendWith({MockitoExtension.class})
+@AutoConfigureRestDocs
+@WebMvcTest(
+	value = BattleController.class,
+	excludeFilters = @ComponentScan.Filter(
+		type = FilterType.ASSIGNABLE_TYPE,
+		classes = TokenAuthenticationFilter.class
+	)
+)
+class BattleRandomRestDocsTest {
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@MockBean
+	private PrincipalService principalService;
+
+	@MockBean
+	private BattleService battleService;
+
+	@MockBean
+	private VoteService voteService;
+
+	@Test
+	void 성공_랜덤한_대결_상세정보를_조회할_수_있다() throws Exception {
+		// given
+		BattleDetailsResponseDto responseDto = createResponse();
+		// when
+		when(battleService.getRandomBattleDetail())
+			.thenReturn(responseDto);
+		ResultActions actions = mockMvc.perform(get("/api/v1/battles/random")
+			.contentType(MediaType.APPLICATION_JSON));
+		// then
+		actions
+			.andExpect(status().isOk())
+			.andDo(document("success-battle-random",
+				responseFields(
+					fieldWithPath("success").type(JsonFieldType.BOOLEAN)
+						.description("API 요청 성공 여부"),
+					fieldWithPath("message").type(JsonFieldType.STRING)
+						.description("API 요청 응답 메시지"),
+					fieldWithPath("data").type(JsonFieldType.OBJECT)
+						.description("API 요청 응답 데이터"),
+					fieldWithPath("data.battleId").type(JsonFieldType.NUMBER)
+						.description("진행중인 대결 ID"),
+					fieldWithPath("data.battleGenre").type(JsonFieldType.OBJECT)
+						.description("대결의 장르"),
+					fieldWithPath("data.battleGenre.genreValue").type(JsonFieldType.STRING)
+						.description("대결의 장르 enum 값"),
+					fieldWithPath("data.battleGenre.genreName").type(JsonFieldType.STRING)
+						.description("대결의 장르명"),
+					fieldWithPath("data.challenged").type(JsonFieldType.OBJECT)
+						.description("대결 신청을 받은 게시물 대결 정보"),
+					fieldWithPath("data.challenged.postId").type(JsonFieldType.NUMBER)
+						.description("대결 신청을 받은 게시물 ID"),
+					fieldWithPath("data.challenged.music").type(JsonFieldType.OBJECT)
+						.description("대결 신청을 받은 게시물에서 공유한 음악 정보"),
+					fieldWithPath("data.challenged.music.musicId").type(JsonFieldType.STRING)
+						.description("대결 신청을 받은 게시물에서 공유한 음악의 고유 번호"),
+					fieldWithPath("data.challenged.music.singer").type(JsonFieldType.STRING)
+						.description("대결 신청을 받은 게시물에서 공유한 음악의 가수명"),
+					fieldWithPath("data.challenged.music.title").type(JsonFieldType.STRING)
+						.description("대결 신청을 받은 게시물에서 공유한 음악의 제목"),
+					fieldWithPath("data.challenged.music.genre").type(JsonFieldType.OBJECT)
+						.description("대결 신청을 받은 게시물에서 공유한 음악의 장르"),
+					fieldWithPath("data.challenged.music.genre.genreValue").type(JsonFieldType.STRING)
+						.description("대결 신청을 받은 게시물에서 공유한 음악의 장르 enum 값"),
+					fieldWithPath("data.challenged.music.genre.genreName").type(JsonFieldType.STRING)
+						.description("대결 신청을 받은 게시물에서 공유한 음악의 장르명"),
+					fieldWithPath("data.challenged.music.musicUrl").type(JsonFieldType.STRING)
+						.description("대결 신청을 받은 게시물에서 공유한 음악의 재생 URL"),
+					fieldWithPath("data.challenged.music.albumCoverUrl").type(JsonFieldType.STRING)
+						.description("대결 신청을 받은 게시물에서 공유한 음악의 앨범 커버 URL"),
+					fieldWithPath("data.challenging").type(JsonFieldType.OBJECT)
+						.description("대결을 신청한 게시물 대결 정보"),
+					fieldWithPath("data.challenging.postId").type(JsonFieldType.NUMBER)
+						.description("대결을 신청한 게시물 ID"),
+					fieldWithPath("data.challenging.music").type(JsonFieldType.OBJECT)
+						.description("대결을 신청한 게시물에서 공유한 음악 정보"),
+					fieldWithPath("data.challenging.music.musicId").type(JsonFieldType.STRING)
+						.description("대결을 신청한 게시물에서 공유한 음악의 고유 번호"),
+					fieldWithPath("data.challenging.music.singer").type(JsonFieldType.STRING)
+						.description("대결을 신청한 게시물에서 공유한 음악의 가수명"),
+					fieldWithPath("data.challenging.music.title").type(JsonFieldType.STRING)
+						.description("대결을 신청한 게시물에서 공유한 음악의 제목"),
+					fieldWithPath("data.challenging.music.genre").type(JsonFieldType.OBJECT)
+						.description("대결을 신청한 게시물에서 공유한 음악의 장르"),
+					fieldWithPath("data.challenging.music.genre.genreValue").type(JsonFieldType.STRING)
+						.description("대결을 신청한 게시물에서 공유한 음악의 장르 enum 값"),
+					fieldWithPath("data.challenging.music.genre.genreName").type(JsonFieldType.STRING)
+						.description("대결을 신청한 게시물에서 공유한 음악의 장르명"),
+					fieldWithPath("data.challenging.music.musicUrl").type(JsonFieldType.STRING)
+						.description("대결을 신청한 게시물에서 공유한 음악의 재생 URL"),
+					fieldWithPath("data.challenging.music.albumCoverUrl").type(JsonFieldType.STRING)
+						.description("대결을 신청한 게시물에서 공유한 음악의 앨범 커버 URL")
+				)));
+	}
+
+	@Test
+	void 실패_진행중인_대결이_없으면_랜덤한_대결_상세정보를_조회할_수_없다() throws Exception {
+		// given
+		BattleDetailsResponseDto responseDto = createResponse();
+		// when
+		when(battleService.getRandomBattleDetail())
+			.thenThrow(new IllegalArgumentException(ExceptionMessage.NOT_PROGRESS_BATTLE.getMessage()));
+		ResultActions actions = mockMvc.perform(get("/api/v1/battles/random")
+			.contentType(MediaType.APPLICATION_JSON));
+		// then
+		actions
+			.andExpect(status().isBadRequest())
+			.andDo(document("fail-battle-random",
+				responseFields(
+					fieldWithPath("success").type(JsonFieldType.BOOLEAN)
+						.description("API 요청 성공 여부"),
+					fieldWithPath("message").type(JsonFieldType.STRING)
+						.description("API 요청 응답 메시지"),
+					fieldWithPath("data").type(JsonFieldType.NULL)
+						.description("API 요청 응답 데이터")
+				)));
+	}
+
+	private BattleDetailsResponseDto createResponse() {
+		return BattleDetailsResponseDto.builder()
+			.battleId(1L)
+			.battleGenre(GenreVoResponseDto.of(Genre.CLASSIC))
+			.challenged(new BattlePostResponseVo(
+				1L,
+				MusicVoResponseDto.of(
+					new Music(
+						"ABCD1234",
+						"albumCoverUrl",
+						"singer",
+						"title",
+						Genre.CLASSIC,
+						"musicUrl"
+					)
+				)
+			))
+			.challenging(new BattlePostResponseVo(
+				2L,
+				MusicVoResponseDto.of(
+					new Music(
+						"ABCD1235",
+						"albumCoverUrl2",
+						"singer2",
+						"title2",
+						Genre.CLASSIC,
+						"musicUrl2"
+					)
+				)
+			))
+			.build();
+	}
+}


### PR DESCRIPTION
## PR Description 🗒️

## 추가/변경 사항 및 설명 📝
- 랜덤한 배틀 상세정보 조회 기능 (진행중인 배틀만 가져오기)
- RestDocs 테스트 추가.

## To Reviewers 🙏
- 포스트맨으로 찔렀을떄 동작하는 것을 확인했습니다.
- 테스트 코드는 배포하고 추가하도록 하겠습니다.

## Issue close ✂️
#197 