### PR TITLE
[FEAT] 애플뮤직 API로 음악 검색 키워드를 받아서 대신 요청하는 API 추가.

### DIFF
--- a/src/main/java/com/example/demo/common/ExceptionMessage.java
+++ b/src/main/java/com/example/demo/common/ExceptionMessage.java
@@ -25,6 +25,7 @@ public enum ExceptionMessage {
 	CANNOT_MAKE_BATTLE_ALREADY_EXIST_PROGRESS_BATTLE("해당 post들에 대한 진행중인 battle이 이미 존재합니다."),
 	NOT_ALLOWED_FILE_FORMAT("허용되지 않는 파일 형식입니다."),
 	NOT_PROGRESS_BATTLE("진행중인 배틀이 없습니다."),
+	NOT_VALID_TERM("검색 요청값이 올바른 형태가 아닙니다."),
 
 	// IllegalStateException
 	FAIL_UPLOAD_FILE_S3("저장소에 파일 업로드가 실패했습니다."),
@@ -38,7 +39,10 @@ public enum ExceptionMessage {
 	CANNOT_NICKNAME_BLANK("닉네임은 공백만으로 이루어 질 수 없습니다."),
 
 	//NumberFormatException
-	CANNOT_ACCESS_ANONYMOUS("로그인 하지 않은 사용자는 접근할 수 없습니다.");
+	CANNOT_ACCESS_ANONYMOUS("로그인 하지 않은 사용자는 접근할 수 없습니다."),
+
+	//IOException
+	FAIL_SEARCH_MUSIC("음악 검색에 실패했습니다.");
 
 	final String message;
 

--- a/src/main/java/com/example/demo/common/ResponseMessage.java
+++ b/src/main/java/com/example/demo/common/ResponseMessage.java
@@ -25,7 +25,9 @@ public enum ResponseMessage {
 	SUCCESS_FIND_BATTLES("대결 리스트 조회 성공"),
 	SUCCESS_FIND_BATTLE_DETAIL_BY_ID("배틀 상세 조회 성공"),
 	SUCCESS_RANDOM_BATTLE("랜덤한 대결 상세 조회 성공"),
-	SUCCESS_GET_IS_LIKE("좋아요 여부 판단 성공");
+	SUCCESS_GET_IS_LIKE("좋아요 여부 판단 성공"),
+	// Music
+	SUCCESS_MUSIC_SEARCH("음악 검색 성공");
 
 	final String message;
 

--- a/src/main/java/com/example/demo/controller/MusicController.java
+++ b/src/main/java/com/example/demo/controller/MusicController.java
@@ -1,0 +1,36 @@
+package com.example.demo.controller;
+
+import static com.example.demo.common.ResponseMessage.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.demo.common.ApiResponse;
+import com.example.demo.service.MusicSearchService;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/music")
+public class MusicController {
+
+	private final MusicSearchService musicSearchService;
+
+	@GetMapping("/search")
+	ResponseEntity<ApiResponse> getResultByMusicSearchApi(
+		@RequestParam String term
+	) {
+		JsonNode search = musicSearchService.search(term);
+		return ResponseEntity.ok(
+			ApiResponse.success(
+				SUCCESS_MUSIC_SEARCH.getMessage(),
+				search
+			)
+		);
+	}
+}

--- a/src/main/java/com/example/demo/service/ItunesMusicSearchService.java
+++ b/src/main/java/com/example/demo/service/ItunesMusicSearchService.java
@@ -1,0 +1,46 @@
+package com.example.demo.service;
+
+import static com.example.demo.common.ExceptionMessage.*;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClients;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ItunesMusicSearchService implements MusicSearchService {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public JsonNode search(String term) {
+		HttpClient httpClient = HttpClients.createDefault();
+		try {
+			String requestUrl = String.format(
+				"https://itunes.apple.com/search?term=%s&country=KR&media=music",
+				URLEncoder.encode(term, StandardCharsets.UTF_8));
+
+			HttpGet httpGet = new HttpGet(requestUrl);
+			HttpResponse response = httpClient.execute(httpGet);
+			int httpStatusCode = response.getStatusLine().getStatusCode();
+
+			if (httpStatusCode < 200 || httpStatusCode >= 300) {
+				throw new IOException(FAIL_SEARCH_MUSIC.getMessage());
+			}
+			return objectMapper.readTree(response.getEntity().getContent());
+		} catch (IOException exception) {
+			throw new IllegalArgumentException(NOT_VALID_TERM.getMessage());
+		}
+	}
+}

--- a/src/main/java/com/example/demo/service/MusicSearchService.java
+++ b/src/main/java/com/example/demo/service/MusicSearchService.java
@@ -1,0 +1,7 @@
+package com.example.demo.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public interface MusicSearchService {
+	JsonNode search(String term);
+}

--- a/src/test/java/com/example/demo/controller/music/MusicSearchRestDocsTest.java
+++ b/src/test/java/com/example/demo/controller/music/MusicSearchRestDocsTest.java
@@ -1,0 +1,122 @@
+package com.example.demo.controller.music;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.demo.service.MusicSearchService;
+
+@WithMockUser
+@ExtendWith(RestDocumentationExtension.class)
+@Transactional
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MusicSearchRestDocsTest {
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@Autowired
+	private MusicSearchService musicSearchService;
+
+	@Test
+	void 성공_음악을_검색할_수_있다() throws Exception {
+		// when
+		ResultActions actions = mockMvc.perform(get("/api/v1/music/search")
+			.contentType(MediaType.APPLICATION_JSON)
+			.param("term", "아이유 좋은 날"));
+		// then
+		actions
+			.andExpect(status().isOk())
+			.andDo(document("success-music-search",
+				responseFields(
+					fieldWithPath("success").type(JsonFieldType.BOOLEAN)
+						.description("API 요청 성공 여부"),
+					fieldWithPath("message").type(JsonFieldType.STRING)
+						.description("API 요청 응답 메시지"),
+					fieldWithPath("data").type(JsonFieldType.OBJECT)
+						.description("API 요청 응답 데이터"),
+					fieldWithPath("data.resultCount").type(JsonFieldType.NUMBER)
+						.description("음악 검색 결과 개수"),
+					fieldWithPath("data.results").type(JsonFieldType.ARRAY)
+						.description("음악 검색 결과 데이터"),
+					fieldWithPath("data.results[].wrapperType").type(JsonFieldType.STRING)
+						.description("검색 결과에 대해 반환되는 객체 이름"),
+					fieldWithPath("data.results[].kind").type(JsonFieldType.STRING)
+						.description("검색 결과에 대한 내용의 종류"),
+					fieldWithPath("data.results[].artistId").type(JsonFieldType.NUMBER)
+						.description("아티스트 고유 ID"),
+					fieldWithPath("data.results[].collectionId").type(JsonFieldType.NUMBER)
+						.description("앨범 고유 ID"),
+					fieldWithPath("data.results[].trackId").type(JsonFieldType.NUMBER)
+						.description("음악 고유 ID"),
+					fieldWithPath("data.results[].artistName").type(JsonFieldType.STRING)
+						.description("아티스트 이름"),
+					fieldWithPath("data.results[].collectionName").type(JsonFieldType.STRING)
+						.description("앨범 이름"),
+					fieldWithPath("data.results[].trackName").type(JsonFieldType.STRING)
+						.description("음악 제목"),
+					fieldWithPath("data.results[].collectionCensoredName").type(JsonFieldType.STRING)
+						.description("걸러진 앨범 이름"),
+					fieldWithPath("data.results[].trackCensoredName").type(JsonFieldType.STRING)
+						.description("걸러진 음악 제목"),
+					fieldWithPath("data.results[].artistViewUrl").type(JsonFieldType.STRING)
+						.description("애플뮤직의 해당 아티스트 페이지"),
+					fieldWithPath("data.results[].collectionViewUrl").type(JsonFieldType.STRING)
+						.description("애플뮤직의 해당 앨범 페이지"),
+					fieldWithPath("data.results[].trackViewUrl").type(JsonFieldType.STRING)
+						.description("애플뮤직의 해당 음악 페이지"),
+					fieldWithPath("data.results[].previewUrl").type(JsonFieldType.STRING)
+						.description("음악 미리듣기 Url"),
+					fieldWithPath("data.results[].artworkUrl30").type(JsonFieldType.STRING)
+						.description("앨범 커버 크기 30"),
+					fieldWithPath("data.results[].artworkUrl60").type(JsonFieldType.STRING)
+						.description("앨범 커버 크기 60"),
+					fieldWithPath("data.results[].artworkUrl100").type(JsonFieldType.STRING)
+						.description("앨범 커버 크기 100"),
+					fieldWithPath("data.results[].releaseDate").type(JsonFieldType.STRING)
+						.description("음악 발매 일자"),
+					fieldWithPath("data.results[].collectionExplicitness").type(JsonFieldType.STRING)
+						.description("앨범 수집 명시성"),
+					fieldWithPath("data.results[].trackExplicitness").type(JsonFieldType.STRING)
+						.description("음악 수집 명시성"),
+					fieldWithPath("data.results[].discCount").type(JsonFieldType.NUMBER)
+						.description("앨범의 디스크 개수"),
+					fieldWithPath("data.results[].discNumber").type(JsonFieldType.NUMBER)
+						.description("앨범의 디스크 번호"),
+					fieldWithPath("data.results[].trackCount").type(JsonFieldType.NUMBER)
+						.description("앨범의 트랙 개수"),
+					fieldWithPath("data.results[].trackNumber").type(JsonFieldType.NUMBER)
+						.description("앨범의 트랙 번호"),
+					fieldWithPath("data.results[].trackTimeMillis").type(JsonFieldType.NUMBER)
+						.description("앨범 청취 시간"),
+					fieldWithPath("data.results[].country").type(JsonFieldType.STRING)
+						.description("나라"),
+					fieldWithPath("data.results[].currency").type(JsonFieldType.STRING)
+						.description("통화"),
+					fieldWithPath("data.results[].primaryGenreName").type(JsonFieldType.STRING)
+						.description("음악 장르 이름"),
+					fieldWithPath("data.results[].isStreamable").type(JsonFieldType.BOOLEAN)
+						.description("스트리밍 가능 여부")
+				)));
+	}
+
+}


### PR DESCRIPTION
## PR Description 🗒️

## 추가/변경 사항 및 설명 📝
- IOS를 사용하는 유저들은 CORS 에러가 터져서 이를 방지하기 위해서 백엔드 서버에서 애플뮤직 api로 대신 요청을 보내는 API 추가.
- 확장성을 위해서 인터페이스를 이용하여 구현.
- RestDocs와 통합 테스트(성공로직)을 한번에 추가.

## Issue close ✂️
closed #206 