### PR TITLE
[FIX] 랜덤한 대결 뽑는 기능 로직 수정.

### DIFF
--- a/src/main/java/com/example/demo/repository/BattleRepository.java
+++ b/src/main/java/com/example/demo/repository/BattleRepository.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 
 import javax.persistence.LockModeType;
 
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -39,7 +38,5 @@ public interface BattleRepository extends JpaRepository<Battle, Long> {
 		Post challengedPost, Post challengingPost, BattleStatus battleStatus
 	);
 
-	@Query("SELECT b FROM Battle b WHERE b.id >= :id and b.status = :status ORDER BY b.id asc")
-	List<Battle> findRandomBattle(
-		@Param("id") Long id, @Param("status") BattleStatus status, Pageable pageable);
+	List<Battle> findByStatus(BattleStatus status);
 }

--- a/src/main/java/com/example/demo/service/BattleService.java
+++ b/src/main/java/com/example/demo/service/BattleService.java
@@ -213,13 +213,13 @@ public class BattleService {
 	}
 
 	public BattleDetailsResponseDto getRandomBattleDetail() {
-		List<Battle> randomBattle = battleRepository.findByStatus(BattleStatus.PROGRESS);
-		if (randomBattle.size() < 1) {
+		List<Battle> progressBattles = battleRepository.findByStatus(BattleStatus.PROGRESS);
+		if (progressBattles.size() < 1) {
 			throw new IllegalArgumentException(NOT_PROGRESS_BATTLE.getMessage());
 		}
 
-		int randomIndex = new Random().nextInt(randomBattle.size());
-		return BattleDetailsResponseDto.of(randomBattle.get(randomIndex));
+		int randomIndex = new Random().nextInt(progressBattles.size());
+		return BattleDetailsResponseDto.of(progressBattles.get(randomIndex));
 	}
 }
 

--- a/src/main/java/com/example/demo/service/BattleService.java
+++ b/src/main/java/com/example/demo/service/BattleService.java
@@ -11,7 +11,6 @@ import java.util.Random;
 
 import javax.persistence.EntityNotFoundException;
 
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,7 +30,9 @@ import com.example.demo.repository.PostRepository;
 import com.example.demo.repository.VoteRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -212,15 +213,13 @@ public class BattleService {
 	}
 
 	public BattleDetailsResponseDto getRandomBattleDetail() {
-		long count = battleRepository.count();
-		long randomIndex = new Random().nextInt((int)count) + 1;
-		List<Battle> randomBattle = battleRepository.findRandomBattle(randomIndex, BattleStatus.PROGRESS,
-			PageRequest.of(0, 1));
-
+		List<Battle> randomBattle = battleRepository.findByStatus(BattleStatus.PROGRESS);
 		if (randomBattle.size() < 1) {
 			throw new IllegalArgumentException(NOT_PROGRESS_BATTLE.getMessage());
 		}
-		return BattleDetailsResponseDto.of(randomBattle.get(0));
+
+		int randomIndex = new Random().nextInt(randomBattle.size());
+		return BattleDetailsResponseDto.of(randomBattle.get(randomIndex));
 	}
 }
 

--- a/src/main/java/com/example/demo/service/BattleService.java
+++ b/src/main/java/com/example/demo/service/BattleService.java
@@ -30,9 +30,7 @@ import com.example.demo.repository.PostRepository;
 import com.example.demo.repository.VoteRepository;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor


### PR DESCRIPTION
## PR Description 🗒️

## 추가/변경 사항 및 설명 📝
- 기존 방식은 count를 받아서 1부터 count까지 중의 랜덤한 number를 뽑고 그 number보다 더 큰 id 중 진행중인 대결 맨 앞의 하나를 꺼내오는 로직이었음.
- 근데 이 방식의 문제가 대결 개수가 많아지면 뽑히는 number가 엄청 큰 값이 나오지 않는 이상 그 값보다 큰 number를 가진 id의 진행중인 대결은 항상 가장 최근 대결로 뽑히는 문제가 있음.
- 이를 해결하는 방법을 생각해봤으나 다 별로라는 생각이 들었고 어짜피 대결이 진행중인 것들은 오늘 생성된 대결 밖에 없을 것이기에 이를 메모리 상에 올려도 큰 부하는 없을 것이라 판단하여 진행중인 대결을 다 들고 오고 이 중 랜덤한 배틀을 선택하는 방식으로 수정.

## Issue close ✂️
closed #212 
