### PR TITLE
[FIX] 음악 검색 api 내려줄 때 음악 재생 url이 존재하지 않는 경우 필터링 하도록 수정.

### DIFF
--- a/src/main/java/com/example/demo/controller/MusicController.java
+++ b/src/main/java/com/example/demo/controller/MusicController.java
@@ -9,8 +9,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.demo.common.ApiResponse;
+import com.example.demo.dto.music.MusicSearchResponseDto;
 import com.example.demo.service.MusicSearchService;
-import com.fasterxml.jackson.databind.JsonNode;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,11 +25,11 @@ public class MusicController {
 	ResponseEntity<ApiResponse> getResultByMusicSearchApi(
 		@RequestParam String term
 	) {
-		JsonNode search = musicSearchService.search(term);
+		MusicSearchResponseDto searchResult = musicSearchService.search(term);
 		return ResponseEntity.ok(
 			ApiResponse.success(
 				SUCCESS_MUSIC_SEARCH.getMessage(),
-				search
+				searchResult
 			)
 		);
 	}

--- a/src/main/java/com/example/demo/dto/music/MusicSearchResponseDto.java
+++ b/src/main/java/com/example/demo/dto/music/MusicSearchResponseDto.java
@@ -1,0 +1,15 @@
+package com.example.demo.dto.music;
+
+import java.util.List;
+
+public record MusicSearchResponseDto(
+	int resultCount,
+	List<MusicSearchResponseVo> results
+) {
+	public static MusicSearchResponseDto of(List<MusicSearchResponseVo> musicList) {
+		return new MusicSearchResponseDto(
+			musicList.size(),
+			musicList
+		);
+	}
+}

--- a/src/main/java/com/example/demo/dto/music/MusicSearchResponseVo.java
+++ b/src/main/java/com/example/demo/dto/music/MusicSearchResponseVo.java
@@ -1,0 +1,34 @@
+package com.example.demo.dto.music;
+
+public record MusicSearchResponseVo(
+	String wrapperType,
+	String kind,
+	Long artistId,
+	Long collectionId,
+	Long trackId,
+	String artistName,
+	String collectionName,
+	String trackName,
+	String collectionCensoredName,
+	String trackCensoredName,
+	String artistViewUrl,
+	String collectionViewUrl,
+	String trackViewUrl,
+	String previewUrl,
+	String artworkUrl30,
+	String artworkUrl60,
+	String artworkUrl100,
+	String releaseDate,
+	String collectionExplicitness,
+	String trackExplicitness,
+	int discCount,
+	int discNumber,
+	int trackCount,
+	int trackNumber,
+	Long trackTimeMillis,
+	String country,
+	String currency,
+	String primaryGenreName,
+	Boolean isStreamable
+) {
+}

--- a/src/main/java/com/example/demo/service/ItunesMusicSearchService.java
+++ b/src/main/java/com/example/demo/service/ItunesMusicSearchService.java
@@ -56,8 +56,8 @@ public class ItunesMusicSearchService implements MusicSearchService {
 
 			List<MusicSearchResponseVo> convertJsonToDtoNotBlankMusicUrl = convertJsonToDto.stream()
 				.filter(musicSearchResponseVo ->
-					Objects.nonNull(musicSearchResponseVo.previewUrl()) &&
-						!musicSearchResponseVo.previewUrl().isBlank()
+					Objects.nonNull(musicSearchResponseVo.previewUrl())
+						&& !musicSearchResponseVo.previewUrl().isBlank()
 				)
 				.toList();
 

--- a/src/main/java/com/example/demo/service/ItunesMusicSearchService.java
+++ b/src/main/java/com/example/demo/service/ItunesMusicSearchService.java
@@ -7,6 +7,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
@@ -54,7 +55,10 @@ public class ItunesMusicSearchService implements MusicSearchService {
 					MusicSearchResponseVo[].class));
 
 			List<MusicSearchResponseVo> convertJsonToDtoNotBlankMusicUrl = convertJsonToDto.stream()
-				.filter(musicSearchResponseVo -> !musicSearchResponseVo.previewUrl().isBlank())
+				.filter(musicSearchResponseVo ->
+					Objects.nonNull(musicSearchResponseVo.previewUrl()) &&
+						!musicSearchResponseVo.previewUrl().isBlank()
+				)
 				.toList();
 
 			return MusicSearchResponseDto.of(

--- a/src/main/java/com/example/demo/service/ItunesMusicSearchService.java
+++ b/src/main/java/com/example/demo/service/ItunesMusicSearchService.java
@@ -5,6 +5,8 @@ import static com.example.demo.common.ExceptionMessage.*;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
@@ -12,11 +14,16 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.HttpClients;
 import org.springframework.stereotype.Service;
 
+import com.example.demo.dto.music.MusicSearchResponseDto;
+import com.example.demo.dto.music.MusicSearchResponseVo;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ItunesMusicSearchService implements MusicSearchService {
@@ -24,7 +31,7 @@ public class ItunesMusicSearchService implements MusicSearchService {
 	private final ObjectMapper objectMapper;
 
 	@Override
-	public JsonNode search(String term) {
+	public MusicSearchResponseDto search(String term) {
 		HttpClient httpClient = HttpClients.createDefault();
 		try {
 			String requestUrl = String.format(
@@ -38,7 +45,21 @@ public class ItunesMusicSearchService implements MusicSearchService {
 			if (httpStatusCode < 200 || httpStatusCode >= 300) {
 				throw new IOException(FAIL_SEARCH_MUSIC.getMessage());
 			}
-			return objectMapper.readTree(response.getEntity().getContent());
+
+			JsonNode jsonNode = objectMapper.readTree(response.getEntity().getContent());
+			ArrayNode results = (ArrayNode)jsonNode.get("results");
+			List<MusicSearchResponseVo> convertJsonToDto = Arrays.asList(
+				objectMapper.convertValue(
+					results,
+					MusicSearchResponseVo[].class));
+
+			List<MusicSearchResponseVo> convertJsonToDtoNotBlankMusicUrl = convertJsonToDto.stream()
+				.filter(musicSearchResponseVo -> !musicSearchResponseVo.previewUrl().isBlank())
+				.toList();
+
+			return MusicSearchResponseDto.of(
+				convertJsonToDtoNotBlankMusicUrl
+			);
 		} catch (IOException exception) {
 			throw new IllegalArgumentException(NOT_VALID_TERM.getMessage());
 		}

--- a/src/main/java/com/example/demo/service/MusicSearchService.java
+++ b/src/main/java/com/example/demo/service/MusicSearchService.java
@@ -1,7 +1,7 @@
 package com.example.demo.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import com.example.demo.dto.music.MusicSearchResponseDto;
 
 public interface MusicSearchService {
-	JsonNode search(String term);
+	MusicSearchResponseDto search(String term);
 }


### PR DESCRIPTION
## PR Description 🗒️

## 추가/변경 사항 및 설명 📝
- 애플뮤직에서 받은 json을 dto로 변환해서 List로 구현.
- filter를 이용해서 재생 Url이 null이거나 비어있는 경우는 걸러내게 구현.

## Issue close ✂️
closed #215 