### PR TITLE
[FEAT] 게시글 수정 기능 구현

### DIFF
--- a/src/main/java/com/example/demo/common/ExceptionMessage.java
+++ b/src/main/java/com/example/demo/common/ExceptionMessage.java
@@ -26,6 +26,8 @@ public enum ExceptionMessage {
 	NOT_ALLOWED_FILE_FORMAT("허용되지 않는 파일 형식입니다."),
 	NOT_PROGRESS_BATTLE("진행중인 배틀이 없습니다."),
 	NOT_VALID_TERM("검색 요청값이 올바른 형태가 아닙니다."),
+	NOT_POST_OWNER("해당 게시글의 작성자가 아닙니다."),
+	NOT_EXIST_UPDATE_DATA("request body에 담긴 수정할 데이터가 없습니다."),
 
 	// IllegalStateException
 	FAIL_UPLOAD_FILE_S3("저장소에 파일 업로드가 실패했습니다."),

--- a/src/main/java/com/example/demo/common/ResponseMessage.java
+++ b/src/main/java/com/example/demo/common/ResponseMessage.java
@@ -17,6 +17,7 @@ public enum ResponseMessage {
 	SUCCESS_FIND_POST("음악 추천 게시글 상세 조회 성공"),
 	SUCCESS_LIKE_POST("추천글 좋아요 성공"),
 	SUCCESS_UNLIKE_POST("추천글 좋아요 해제 성공"),
+	SUCCESS_UPDATE_POST("음악 추천 게시글 수정 성공"),
 	// Battle
 	SUCCESS_FIND_ALL_CANDIDATE_POST("대결곡 후보 게시글 리스트 조회 성공"),
 	SUCCESS_FIND_ALL_BATTLE_DETAILS("대결 상세 정보 리스트 조회 성공"),

--- a/src/main/java/com/example/demo/controller/PostController.java
+++ b/src/main/java/com/example/demo/controller/PostController.java
@@ -5,8 +5,12 @@ import static com.example.demo.common.ResponseMessage.*;
 import java.net.URI;
 import java.security.Principal;
 
+import javax.validation.Valid;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,6 +24,7 @@ import com.example.demo.dto.post.PostCreateRequestDto;
 import com.example.demo.dto.post.PostDetailFindResponseDto;
 import com.example.demo.dto.post.PostIsLikeResponseDto;
 import com.example.demo.dto.post.PostLikeResponseDto;
+import com.example.demo.dto.post.PostUpdateRequestDto;
 import com.example.demo.dto.post.PostsBattleCandidateResponseDto;
 import com.example.demo.dto.post.PostsFindResponseDto;
 import com.example.demo.model.post.Genre;
@@ -38,7 +43,7 @@ public class PostController {
 
 	@PostMapping
 	public ResponseEntity<ApiResponse> createPost(
-		Principal principal, @RequestBody PostCreateRequestDto postRequestDto) {
+		Principal principal, @Valid @RequestBody PostCreateRequestDto postRequestDto) {
 		Long postId = postService.createPost(principal, postRequestDto);
 
 		URI location = ServletUriComponentsBuilder.fromCurrentRequest()
@@ -104,7 +109,9 @@ public class PostController {
 	}
 
 	@GetMapping("/{postId}/isLike")
-	public ResponseEntity<ApiResponse> getPostIsLiked(Principal principal, @PathVariable("postId") Long postId) {
+	public ResponseEntity<ApiResponse> getPostIsLiked(
+		Principal principal,
+		@PathVariable("postId") Long postId) {
 		PostIsLikeResponseDto result = postService.getPostIsLiked(principal, postId);
 
 		ApiResponse apiResponse = ApiResponse.success(SUCCESS_GET_IS_LIKE.getMessage(), result);
@@ -112,4 +119,15 @@ public class PostController {
 		return ResponseEntity.ok(apiResponse);
 	}
 
+	@PatchMapping("/{postId}")
+	public ResponseEntity<Void> updatePost(
+		Principal principal,
+		@PathVariable Long postId,
+		@RequestBody PostUpdateRequestDto request
+	) {
+
+		postService.update(principal, postId, request);
+
+		return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+	}
 }

--- a/src/main/java/com/example/demo/dto/post/PostUpdateRequestDto.java
+++ b/src/main/java/com/example/demo/dto/post/PostUpdateRequestDto.java
@@ -1,0 +1,29 @@
+package com.example.demo.dto.post;
+
+import com.example.demo.model.post.Genre;
+
+import lombok.Builder;
+import reactor.util.annotation.Nullable;
+
+@Builder
+public record PostUpdateRequestDto(
+	@Nullable String musicId,
+	@Nullable String title,
+	@Nullable String musicUrl,
+	@Nullable String albumCoverUrl,
+	@Nullable Genre genre,
+	@Nullable String singer,
+	@Nullable Boolean battlePossible,
+	@Nullable String content
+) {
+
+	public boolean isAllDataNull() {
+		return musicId == null && title == null && musicUrl == null && albumCoverUrl == null && genre == null
+			&& singer == null && battlePossible == null && content == null;
+	}
+
+	public boolean isMusicDataNull() {
+		return musicId == null && title == null && musicUrl == null && albumCoverUrl == null && genre == null
+			&& singer == null;
+	}
+}

--- a/src/main/java/com/example/demo/model/post/Post.java
+++ b/src/main/java/com/example/demo/model/post/Post.java
@@ -18,6 +18,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.validation.constraints.Min;
 
+import com.example.demo.dto.post.PostUpdateRequestDto;
 import com.example.demo.model.BaseEntity;
 import com.example.demo.model.battle.Battle;
 import com.example.demo.model.member.Member;
@@ -60,7 +61,7 @@ public class Post extends BaseEntity {
 	@OneToMany(mappedBy = "challengingPost.post")
 	private final List<Battle> challengingBattles = new ArrayList<>();
 
-	@Builder(access = AccessLevel.PRIVATE)
+	@Builder
 	public Post(Music music, String content, boolean isPossibleBattle, int likeCount, Member member) {
 		checkArgument(likeCount >= 0, "좋아요 개수가 음수일 수 없습니다.", likeCount);
 		this.music = music;
@@ -70,12 +71,24 @@ public class Post extends BaseEntity {
 		this.member = member;
 	}
 
-	private void setMember(Member member) {
+	public void setMember(Member member) {
 		if (Objects.nonNull(this.member)) {
 			this.member.getPosts().remove(this);
 		}
 		this.member = member;
 		member.getPosts().add(this);
+	}
+
+	private void setMusic(Music music) {
+		this.music = music;
+	}
+
+	private void setBattlePossible(boolean isPossibleBattle) {
+		this.isPossibleBattle = isPossibleBattle;
+	}
+
+	private void setContent(String content) {
+		this.content = content;
 	}
 
 	public static Post create(String musicId, String albumCoverUrl, String singer, String title, Genre genre,
@@ -103,5 +116,24 @@ public class Post extends BaseEntity {
 		}
 	}
 
-	// TODO: 2023-02-23 포스트가 특정 battle을 가지고 있는지 검증하는 메소드
+	public void update(PostUpdateRequestDto requestDto) {
+		if (!requestDto.isMusicDataNull()) {
+			setMusic(new Music(
+				requestDto.musicId(),
+				requestDto.albumCoverUrl(),
+				requestDto.singer(),
+				requestDto.title(),
+				requestDto.genre(),
+				requestDto.musicUrl())
+			);
+		}
+
+		if (requestDto.battlePossible() != null) {
+			setBattlePossible(requestDto.battlePossible());
+		}
+
+		if (requestDto.content() != null) {
+			setContent(requestDto.content());
+		}
+	}
 }

--- a/src/main/java/com/example/demo/service/PostService.java
+++ b/src/main/java/com/example/demo/service/PostService.java
@@ -1,9 +1,11 @@
 package com.example.demo.service;
 
 import static com.example.demo.common.ExceptionMessage.*;
+import static com.google.common.base.Preconditions.*;
 
 import java.security.Principal;
 import java.util.List;
+import java.util.Objects;
 
 import javax.persistence.EntityNotFoundException;
 
@@ -17,6 +19,7 @@ import com.example.demo.dto.post.PostDetailFindResponseDto;
 import com.example.demo.dto.post.PostFindResponseDto;
 import com.example.demo.dto.post.PostIsLikeResponseDto;
 import com.example.demo.dto.post.PostLikeResponseDto;
+import com.example.demo.dto.post.PostUpdateRequestDto;
 import com.example.demo.dto.post.PostsBattleCandidateResponseDto;
 import com.example.demo.dto.post.PostsFindResponseDto;
 import com.example.demo.model.member.Member;
@@ -154,5 +157,18 @@ public class PostService {
 		return PostIsLikeResponseDto.builder()
 			.isLiked(isLike)
 			.build();
+	}
+
+	@Transactional
+	public void update(Principal principal, Long postId, PostUpdateRequestDto requestDto) {
+		checkArgument(!requestDto.isAllDataNull(), NOT_EXIST_UPDATE_DATA);
+
+		Member member = principalService.getMemberByPrincipal(principal);
+		Post post = postRepository.findById(postId)
+			.orElseThrow(() -> new EntityNotFoundException(NOT_FOUND_POST.getMessage()));
+
+		checkArgument(Objects.equals(member.getId(), post.getMember().getId()), NOT_POST_OWNER);
+
+		post.update(requestDto);
 	}
 }

--- a/src/test/java/com/example/demo/controller/TestUtil.java
+++ b/src/test/java/com/example/demo/controller/TestUtil.java
@@ -10,6 +10,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 import com.example.demo.model.member.Member;
 import com.example.demo.model.member.Social;
+import com.example.demo.model.post.Music;
+import com.example.demo.model.post.Post;
 
 import lombok.AllArgsConstructor;
 
@@ -29,6 +31,16 @@ public class TestUtil {
 			"refreshToken",
 			Social.GOOGLE,
 			"socialId");
+	}
+
+	public static Post createPost(Member member, Music music) {
+		return Post.builder()
+			.music(music)
+			.content("content")
+			.isPossibleBattle(true)
+			.likeCount(0)
+			.member(member)
+			.build();
 	}
 
 	public static class TestAuthentication implements Authentication {

--- a/src/test/java/com/example/demo/controller/member/MemberUpdateRestDocsTest.java
+++ b/src/test/java/com/example/demo/controller/member/MemberUpdateRestDocsTest.java
@@ -51,7 +51,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 		classes = TokenAuthenticationFilter.class
 	)
 )
-@ExtendWith(MockitoExtension.class)
 class MemberUpdateRestDocsTest {
 
 	@Autowired

--- a/src/test/java/com/example/demo/controller/post/PostUpdateRemoveDocsTest.java
+++ b/src/test/java/com/example/demo/controller/post/PostUpdateRemoveDocsTest.java
@@ -1,0 +1,546 @@
+package com.example.demo.controller.post;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.*;
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
+import static com.example.demo.common.ExceptionMessage.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import javax.persistence.EntityNotFoundException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.example.demo.controller.PostController;
+import com.example.demo.dto.post.PostUpdateRequestDto;
+import com.example.demo.model.post.Genre;
+import com.example.demo.security.TokenAuthenticationFilter;
+import com.example.demo.service.PostLockFacade;
+import com.example.demo.service.PostService;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+
+@WithMockUser
+@AutoConfigureRestDocs
+@ExtendWith(MockitoExtension.class)
+@Import({PostService.class, PostLockFacade.class})
+@WebMvcTest(value = PostController.class,
+	excludeFilters = @ComponentScan.Filter(
+		type = FilterType.ASSIGNABLE_TYPE,
+		classes = TokenAuthenticationFilter.class
+	)
+)
+public class PostUpdateRemoveDocsTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	PostService postService;
+
+	@MockBean
+	PostLockFacade postLockFacade;
+
+	private final ObjectMapper mapper = new ObjectMapper().setVisibility(PropertyAccessor.FIELD,
+		JsonAutoDetect.Visibility.ANY);
+
+	@Test
+	void 게시글_콘텐츠_정보를_수정할_수_있다() throws Exception {
+		Long postId = 1L;
+		PostUpdateRequestDto postUpdateRequestDto = PostUpdateRequestDto.builder()
+			.content("교환")
+			.build();
+
+		doNothing().when(postService).update(any(), anyLong(), any());
+		ResultActions actions = mockMvc.perform(patch("/api/v1/posts/{postId}", postId)
+			.contentType(MediaType.APPLICATION_JSON)
+			.header("Authorization", "Bearer accessToken")
+			.content(mapper.writeValueAsString(postUpdateRequestDto))
+			.with(csrf())
+		);
+
+		verify(postService).update(any(), anyLong(), any());
+		actions
+			.andExpect(status().isNoContent())
+			.andDo(document("게시물 수정 성공 - 게시글 한마디 내용 수정",
+				resource(
+					ResourceSnippetParameters.builder().tag("Post")
+						.description("게시물 수정 API")
+						.requestHeaders(
+							headerWithName("Authorization").description("Hype 서비스 Access Token")
+						)
+						.pathParameters(
+							parameterWithName("postId").description("조회할 공유 게시글 id")
+						)
+						.requestFields(
+							fieldWithPath("musicId").type(NULL).description("수정할 음악 id"),
+							fieldWithPath("title").type(NULL).description("수정할 음악 제목"),
+							fieldWithPath("musicUrl").type(NULL).description("수정할 음악 재생 url"),
+							fieldWithPath("albumCoverUrl").type(NULL).description("수정할 음악 앨범 커버 url"),
+							fieldWithPath("genre").type(NULL).description("수정할 음악 장르"),
+							fieldWithPath("singer").type(NULL).description("수정할 음악 가수 이름"),
+							fieldWithPath("battlePossible").type(NULL).description("수정할 게시글 대결 가능 여부"),
+							fieldWithPath("content").type(STRING).description("수정할 게시글 한마디 내용"),
+							fieldWithPath("allDataNull").type(BOOLEAN).description("모든 데이터가 전부 NULL인지 여부"),
+							fieldWithPath("musicDataNull").type(BOOLEAN)
+								.description("음악 정보 데이터(id, title, musicRrl, coverUrl, genre, singer)가 모두 NULL인지 여부")
+						)
+						.build()
+				)
+			));
+	}
+
+	@Test
+	void 게시글_음악_정보를_수정할_수_있다() throws Exception {
+		Long postId = 1L;
+		PostUpdateRequestDto postUpdateRequestDto = PostUpdateRequestDto.builder()
+			.musicId("1")
+			.title("title")
+			.musicUrl("musicUrl")
+			.albumCoverUrl("albumConverUrl")
+			.genre(Genre.EDM)
+			.singer("singer")
+			.build();
+
+		doNothing().when(postService).update(any(), anyLong(), any());
+		ResultActions actions = mockMvc.perform(patch("/api/v1/posts/{postId}", postId)
+			.contentType(MediaType.APPLICATION_JSON)
+			.header("Authorization", "Bearer accessToken")
+			.content(mapper.writeValueAsString(postUpdateRequestDto))
+			.with(csrf())
+		);
+
+		verify(postService).update(any(), anyLong(), any());
+		actions
+			.andExpect(status().isNoContent())
+			.andDo(document("게시물 수정 성공 - 게시글 음악 정보 수정",
+				resource(
+					ResourceSnippetParameters.builder().tag("Post")
+						.description("게시물 수정 API")
+						.requestHeaders(
+							headerWithName("Authorization").description("Hype 서비스 Access Token")
+						)
+						.pathParameters(
+							parameterWithName("postId").description("조회할 공유 게시글 id")
+						)
+						.requestFields(
+							fieldWithPath("musicId").type(STRING).description("수정할 음악 id"),
+							fieldWithPath("title").type(STRING).description("수정할 음악 제목"),
+							fieldWithPath("musicUrl").type(STRING).description("수정할 음악 재생 url"),
+							fieldWithPath("albumCoverUrl").type(STRING).description("수정할 음악 앨범 커버 url"),
+							fieldWithPath("genre").type(STRING).description("수정할 음악 장르"),
+							fieldWithPath("singer").type(STRING).description("수정할 음악 가수 이름"),
+							fieldWithPath("battlePossible").type(NULL).description("수정할 게시글 대결 가능 여부"),
+							fieldWithPath("content").type(NULL).description("수정할 게시글 한마디 내용"),
+							fieldWithPath("allDataNull").type(BOOLEAN).description("모든 데이터가 전부 NULL인지 여부"),
+							fieldWithPath("musicDataNull").type(BOOLEAN)
+								.description("음악 정보 데이터(id, title, musicRrl, coverUrl, genre, singer)가 모두 NULL인지 여부")
+						)
+						.build()
+				)
+			));
+	}
+
+	@Test
+	void 게시글_대결가능유무_정보를_수정할_수_있다() throws Exception {
+		Long postId = 1L;
+		PostUpdateRequestDto postUpdateRequestDto = PostUpdateRequestDto.builder()
+			.battlePossible(true)
+			.build();
+
+		doNothing().when(postService).update(any(), anyLong(), any());
+		ResultActions actions = mockMvc.perform(patch("/api/v1/posts/{postId}", postId)
+			.contentType(MediaType.APPLICATION_JSON)
+			.header("Authorization", "Bearer accessToken")
+			.content(mapper.writeValueAsString(postUpdateRequestDto))
+			.with(csrf())
+		);
+
+		verify(postService).update(any(), anyLong(), any());
+		actions
+			.andExpect(status().isNoContent())
+			.andDo(document("게시물 수정 성공 - 게시글",
+				resource(
+					ResourceSnippetParameters.builder().tag("Post")
+						.description("게시물 수정 API")
+						.requestHeaders(
+							headerWithName("Authorization").description("Hype 서비스 Access Token")
+						)
+						.pathParameters(
+							parameterWithName("postId").description("조회할 공유 게시글 id")
+						)
+						.requestFields(
+							fieldWithPath("musicId").type(NULL).description("수정할 음악 id"),
+							fieldWithPath("title").type(NULL).description("수정할 음악 제목"),
+							fieldWithPath("musicUrl").type(NULL).description("수정할 음악 재생 url"),
+							fieldWithPath("albumCoverUrl").type(NULL).description("수정할 음악 앨범 커버 url"),
+							fieldWithPath("genre").type(NULL).description("수정할 음악 장르"),
+							fieldWithPath("singer").type(NULL).description("수정할 음악 가수 이름"),
+							fieldWithPath("battlePossible").type(BOOLEAN).description("수정할 게시글 대결 가능 여부"),
+							fieldWithPath("content").type(NULL).description("수정할 게시글 한마디 내용"),
+							fieldWithPath("allDataNull").type(BOOLEAN).description("모든 데이터가 전부 NULL인지 여부"),
+							fieldWithPath("musicDataNull").type(BOOLEAN)
+								.description("음악 정보 데이터(id, title, musicRrl, coverUrl, genre, singer)가 모두 NULL인지 여부")
+						)
+						.build()
+				)
+			));
+	}
+
+	@Test
+	void 게시글_모든_정보를_수정할_수_있다() throws Exception {
+		Long postId = 1L;
+		PostUpdateRequestDto postUpdateRequestDto = PostUpdateRequestDto.builder()
+			.musicId("1")
+			.title("title")
+			.musicUrl("musicUrl")
+			.albumCoverUrl("albumConverUrl")
+			.genre(Genre.EDM)
+			.singer("singer")
+			.battlePossible(true)
+			.content("content")
+			.build();
+
+		doNothing().when(postService).update(any(), anyLong(), any());
+		ResultActions actions = mockMvc.perform(patch("/api/v1/posts/{postId}", postId)
+			.contentType(MediaType.APPLICATION_JSON)
+			.header("Authorization", "Bearer accessToken")
+			.content(mapper.writeValueAsString(postUpdateRequestDto))
+			.with(csrf())
+		);
+
+		verify(postService).update(any(), anyLong(), any());
+		actions
+			.andExpect(status().isNoContent())
+			.andDo(document("게시물 수정 성공 - 게시글 대결 가능 유무 수정",
+				resource(
+					ResourceSnippetParameters.builder().tag("Post")
+						.description("게시물 수정 API")
+						.requestHeaders(
+							headerWithName("Authorization").description("Hype 서비스 Access Token")
+						)
+						.pathParameters(
+							parameterWithName("postId").description("조회할 공유 게시글 id")
+						)
+						.requestFields(
+							fieldWithPath("musicId").type(STRING).description("수정할 음악 id"),
+							fieldWithPath("title").type(STRING).description("수정할 음악 제목"),
+							fieldWithPath("musicUrl").type(STRING).description("수정할 음악 재생 url"),
+							fieldWithPath("albumCoverUrl").type(STRING).description("수정할 음악 앨범 커버 url"),
+							fieldWithPath("genre").type(STRING).description("수정할 음악 장르"),
+							fieldWithPath("singer").type(STRING).description("수정할 음악 가수 이름"),
+							fieldWithPath("battlePossible").type(BOOLEAN).description("수정할 게시글 대결 가능 여부"),
+							fieldWithPath("content").type(STRING).description("수정할 게시글 한마디 내용"),
+							fieldWithPath("allDataNull").type(BOOLEAN).description("모든 데이터가 전부 NULL인지 여부"),
+							fieldWithPath("musicDataNull").type(BOOLEAN)
+								.description("음악 정보 데이터(id, title, musicRrl, coverUrl, genre, singer)가 모두 NULL인지 여부")
+						)
+						.build()
+				)
+			));
+	}
+
+	@Test
+	void 게시글이_존재하지_않으면_수정할_수_없다() throws Exception {
+		Long postId = 1L;
+		PostUpdateRequestDto postUpdateRequestDto = PostUpdateRequestDto.builder()
+			.musicId("1")
+			.title("title")
+			.musicUrl("musicUrl")
+			.albumCoverUrl("albumConverUrl")
+			.genre(Genre.EDM)
+			.singer("singer")
+			.battlePossible(true)
+			.content("content")
+			.build();
+
+		doThrow(new EntityNotFoundException(NOT_FOUND_POST.getMessage())).when(postService)
+			.update(any(), anyLong(), any());
+		ResultActions actions = mockMvc.perform(patch("/api/v1/posts/{postId}", postId)
+			.contentType(MediaType.APPLICATION_JSON)
+			.header("Authorization", "Bearer accessToken")
+			.content(mapper.writeValueAsString(postUpdateRequestDto))
+			.with(csrf())
+		);
+
+		verify(postService).update(any(), anyLong(), any());
+		actions
+			.andExpect(status().isNotFound())
+			.andDo(document("게시물 수정 실패 - 게시글이 존재하지 않는 경우",
+				resource(
+					ResourceSnippetParameters.builder().tag("Post")
+						.description("게시물 수정 API")
+						.requestHeaders(
+							headerWithName("Authorization").description("Hype 서비스 Access Token")
+						)
+						.pathParameters(
+							parameterWithName("postId").description("조회할 공유 게시글 id")
+						)
+						.requestFields(
+							fieldWithPath("musicId").type(STRING).description("수정할 음악 id"),
+							fieldWithPath("title").type(STRING).description("수정할 음악 제목"),
+							fieldWithPath("musicUrl").type(STRING).description("수정할 음악 재생 url"),
+							fieldWithPath("albumCoverUrl").type(STRING).description("수정할 음악 앨범 커버 url"),
+							fieldWithPath("genre").type(STRING).description("수정할 음악 장르"),
+							fieldWithPath("singer").type(STRING).description("수정할 음악 가수 이름"),
+							fieldWithPath("battlePossible").type(BOOLEAN).description("수정할 게시글 대결 가능 여부"),
+							fieldWithPath("content").type(STRING).description("수정할 게시글 한마디 내용"),
+							fieldWithPath("allDataNull").type(BOOLEAN).description("모든 데이터가 전부 NULL인지 여부"),
+							fieldWithPath("musicDataNull").type(BOOLEAN)
+								.description("음악 정보 데이터(id, title, musicRrl, coverUrl, genre, singer)가 모두 NULL인지 여부")
+						)
+						.responseFields(
+							fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("API 요청 성공 여부"),
+							fieldWithPath("message").type(JsonFieldType.STRING).description("API 요청 응답 메시지"),
+							fieldWithPath("data").type(JsonFieldType.NULL).description("API 요청 응답 메시지 - Null")
+						)
+						.build()
+				)
+			));
+	}
+
+	@Test
+	void 수정하는_유저가_존재하지_않으면_수정할_수_없다() throws Exception {
+		Long postId = 1L;
+		PostUpdateRequestDto postUpdateRequestDto = PostUpdateRequestDto.builder()
+			.musicId("1")
+			.title("title")
+			.musicUrl("musicUrl")
+			.albumCoverUrl("albumConverUrl")
+			.genre(Genre.EDM)
+			.singer("singer")
+			.battlePossible(true)
+			.content("content")
+			.build();
+
+		doThrow(new EntityNotFoundException(NOT_FOUND_MEMBER.getMessage())).when(postService)
+			.update(any(), anyLong(), any());
+		ResultActions actions = mockMvc.perform(patch("/api/v1/posts/{postId}", postId)
+			.contentType(MediaType.APPLICATION_JSON)
+			.header("Authorization", "Bearer accessToken")
+			.content(mapper.writeValueAsString(postUpdateRequestDto))
+			.with(csrf())
+		);
+
+		verify(postService).update(any(), anyLong(), any());
+		actions
+			.andExpect(status().isNotFound())
+			.andDo(document("게시물 수정 실패 - 수정하려는 유저가 존재하지 않는 경우",
+				resource(
+					ResourceSnippetParameters.builder().tag("Post")
+						.description("게시물 수정 API")
+						.requestHeaders(
+							headerWithName("Authorization").description("Hype 서비스 Access Token")
+						)
+						.pathParameters(
+							parameterWithName("postId").description("조회할 공유 게시글 id")
+						)
+						.requestFields(
+							fieldWithPath("musicId").type(STRING).description("수정할 음악 id"),
+							fieldWithPath("title").type(STRING).description("수정할 음악 제목"),
+							fieldWithPath("musicUrl").type(STRING).description("수정할 음악 재생 url"),
+							fieldWithPath("albumCoverUrl").type(STRING).description("수정할 음악 앨범 커버 url"),
+							fieldWithPath("genre").type(STRING).description("수정할 음악 장르"),
+							fieldWithPath("singer").type(STRING).description("수정할 음악 가수 이름"),
+							fieldWithPath("battlePossible").type(BOOLEAN).description("수정할 게시글 대결 가능 여부"),
+							fieldWithPath("content").type(STRING).description("수정할 게시글 한마디 내용"),
+							fieldWithPath("allDataNull").type(BOOLEAN).description("모든 데이터가 전부 NULL인지 여부"),
+							fieldWithPath("musicDataNull").type(BOOLEAN)
+								.description("음악 정보 데이터(id, title, musicRrl, coverUrl, genre, singer)가 모두 NULL인지 여부")
+						)
+						.responseFields(
+							fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("API 요청 성공 여부"),
+							fieldWithPath("message").type(JsonFieldType.STRING).description("API 요청 응답 메시지"),
+							fieldWithPath("data").type(JsonFieldType.NULL).description("API 요청 응답 메시지 - Null")
+						)
+						.build()
+				)
+			));
+	}
+
+	@Test
+	void 게시글의_게시자가_아니면_수정할_수_없다() throws Exception {
+		Long postId = 1L;
+		PostUpdateRequestDto postUpdateRequestDto = PostUpdateRequestDto.builder()
+			.musicId("1")
+			.title("title")
+			.musicUrl("musicUrl")
+			.albumCoverUrl("albumConverUrl")
+			.genre(Genre.EDM)
+			.singer("singer")
+			.battlePossible(true)
+			.content("content")
+			.build();
+
+		doThrow(new IllegalArgumentException(NOT_POST_OWNER.getMessage())).when(postService)
+			.update(any(), anyLong(), any());
+		ResultActions actions = mockMvc.perform(patch("/api/v1/posts/{postId}", postId)
+			.contentType(MediaType.APPLICATION_JSON)
+			.header("Authorization", "Bearer accessToken")
+			.content(mapper.writeValueAsString(postUpdateRequestDto))
+			.with(csrf())
+		);
+
+		verify(postService).update(any(), anyLong(), any());
+		actions
+			.andExpect(status().isBadRequest())
+			.andDo(document("게시물 수정 실패 - 게시글의 게시자가 아닌 경우",
+				resource(
+					ResourceSnippetParameters.builder().tag("Post")
+						.description("게시물 수정 API")
+						.requestHeaders(
+							headerWithName("Authorization").description("Hype 서비스 Access Token")
+						)
+						.pathParameters(
+							parameterWithName("postId").description("조회할 공유 게시글 id")
+						)
+						.requestFields(
+							fieldWithPath("musicId").type(STRING).description("수정할 음악 id"),
+							fieldWithPath("title").type(STRING).description("수정할 음악 제목"),
+							fieldWithPath("musicUrl").type(STRING).description("수정할 음악 재생 url"),
+							fieldWithPath("albumCoverUrl").type(STRING).description("수정할 음악 앨범 커버 url"),
+							fieldWithPath("genre").type(STRING).description("수정할 음악 장르"),
+							fieldWithPath("singer").type(STRING).description("수정할 음악 가수 이름"),
+							fieldWithPath("battlePossible").type(BOOLEAN).description("수정할 게시글 대결 가능 여부"),
+							fieldWithPath("content").type(STRING).description("수정할 게시글 한마디 내용"),
+							fieldWithPath("allDataNull").type(BOOLEAN).description("모든 데이터가 전부 NULL인지 여부"),
+							fieldWithPath("musicDataNull").type(BOOLEAN)
+								.description("음악 정보 데이터(id, title, musicRrl, coverUrl, genre, singer)가 모두 NULL인지 여부")
+						)
+						.responseFields(
+							fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("API 요청 성공 여부"),
+							fieldWithPath("message").type(JsonFieldType.STRING).description("API 요청 응답 메시지"),
+							fieldWithPath("data").type(JsonFieldType.NULL).description("API 요청 응답 메시지 - Null")
+						)
+						.build()
+				)
+			));
+	}
+
+	@Test
+	void 수정할_음악_정보가_모두_null이_아니고_하나라도_null_이면_수정할_수_없다() throws Exception {
+		Long postId = 1L;
+		PostUpdateRequestDto postUpdateRequestDto = PostUpdateRequestDto.builder()
+			.musicId("1")
+			.title("title")
+			.musicUrl("musicUrl")
+			.albumCoverUrl("albumConverUrl")
+			.genre(Genre.EDM)
+			.singer(null)
+			.build();
+
+		doThrow(new IllegalArgumentException("가수 이름은 Null일 수 없습니다.")).when(postService)
+			.update(any(), anyLong(), any());
+		ResultActions actions = mockMvc.perform(patch("/api/v1/posts/{postId}", postId)
+			.contentType(MediaType.APPLICATION_JSON)
+			.header("Authorization", "Bearer accessToken")
+			.content(mapper.writeValueAsString(postUpdateRequestDto))
+			.with(csrf())
+		);
+
+		verify(postService).update(any(), anyLong(), any());
+		actions
+			.andExpect(status().isBadRequest())
+			.andDo(document("게시물 수정 실패 - 수정할 음악 정보가 하나라도 null인 경우 (전부 null은 상관없음)",
+				resource(
+					ResourceSnippetParameters.builder().tag("Post")
+						.description("게시물 수정 API")
+						.requestHeaders(
+							headerWithName("Authorization").description("Hype 서비스 Access Token")
+						)
+						.pathParameters(
+							parameterWithName("postId").description("조회할 공유 게시글 id")
+						)
+						.requestFields(
+							fieldWithPath("musicId").type(STRING).description("수정할 음악 id"),
+							fieldWithPath("title").type(STRING).description("수정할 음악 제목"),
+							fieldWithPath("musicUrl").type(STRING).description("수정할 음악 재생 url"),
+							fieldWithPath("albumCoverUrl").type(STRING).description("수정할 음악 앨범 커버 url"),
+							fieldWithPath("genre").type(STRING).description("수정할 음악 장르"),
+							fieldWithPath("singer").type(NULL).description("수정할 음악 가수 이름"),
+							fieldWithPath("battlePossible").type(NULL).description("수정할 게시글 대결 가능 여부"),
+							fieldWithPath("content").type(NULL).description("수정할 게시글 한마디 내용"),
+							fieldWithPath("allDataNull").type(BOOLEAN).description("모든 데이터가 전부 NULL인지 여부"),
+							fieldWithPath("musicDataNull").type(BOOLEAN)
+								.description("음악 정보 데이터(id, title, musicRrl, coverUrl, genre, singer)가 모두 NULL인지 여부")
+						)
+						.responseFields(
+							fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("API 요청 성공 여부"),
+							fieldWithPath("message").type(JsonFieldType.STRING).description("API 요청 응답 메시지"),
+							fieldWithPath("data").type(JsonFieldType.NULL).description("API 요청 응답 메시지 - Null")
+						)
+						.build()
+				)
+			));
+	}
+
+	@Test
+	void 수정_요청된_데이터가_없다면_수정할_수_없다() throws Exception {
+		Long postId = 1L;
+		PostUpdateRequestDto postUpdateRequestDto = PostUpdateRequestDto.builder()
+			.build();
+
+		doThrow(new IllegalArgumentException(NOT_EXIST_UPDATE_DATA.getMessage())).when(postService)
+			.update(any(), anyLong(), any());
+		ResultActions actions = mockMvc.perform(patch("/api/v1/posts/{postId}", postId)
+			.contentType(MediaType.APPLICATION_JSON)
+			.header("Authorization", "Bearer accessToken")
+			.content(mapper.writeValueAsString(postUpdateRequestDto))
+			.with(csrf())
+		);
+
+		verify(postService).update(any(), anyLong(), any());
+		actions
+			.andExpect(status().isBadRequest())
+			.andDo(document("게시물 수정 실패 - 모든 수정 요청 정보가 null인 경우",
+				resource(
+					ResourceSnippetParameters.builder().tag("Post")
+						.description("게시물 수정 API")
+						.requestHeaders(
+							headerWithName("Authorization").description("Hype 서비스 Access Token")
+						)
+						.pathParameters(
+							parameterWithName("postId").description("조회할 공유 게시글 id")
+						)
+						.requestFields(
+							fieldWithPath("musicId").type(NULL).description("수정할 음악 id"),
+							fieldWithPath("title").type(NULL).description("수정할 음악 제목"),
+							fieldWithPath("musicUrl").type(NULL).description("수정할 음악 재생 url"),
+							fieldWithPath("albumCoverUrl").type(NULL).description("수정할 음악 앨범 커버 url"),
+							fieldWithPath("genre").type(NULL).description("수정할 음악 장르"),
+							fieldWithPath("singer").type(NULL).description("수정할 음악 가수 이름"),
+							fieldWithPath("battlePossible").type(NULL).description("수정할 게시글 대결 가능 여부"),
+							fieldWithPath("content").type(NULL).description("수정할 게시글 한마디 내용"),
+							fieldWithPath("allDataNull").type(BOOLEAN).description("모든 데이터가 전부 NULL인지 여부"),
+							fieldWithPath("musicDataNull").type(BOOLEAN)
+								.description("음악 정보 데이터(id, title, musicRrl, coverUrl, genre, singer)가 모두 NULL인지 여부")
+						)
+						.responseFields(
+							fieldWithPath("success").type(JsonFieldType.BOOLEAN).description("API 요청 성공 여부"),
+							fieldWithPath("message").type(JsonFieldType.STRING).description("API 요청 응답 메시지"),
+							fieldWithPath("data").type(JsonFieldType.NULL).description("API 요청 응답 메시지 - Null")
+						)
+						.build()
+				)
+			));
+	}
+}

--- a/src/test/java/com/example/demo/controller/post/PostUpdateRemoveTest.java
+++ b/src/test/java/com/example/demo/controller/post/PostUpdateRemoveTest.java
@@ -1,0 +1,74 @@
+package com.example.demo.controller.post;
+
+import static com.example.demo.controller.TestUtil.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.security.Principal;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.demo.controller.PostController;
+import com.example.demo.dto.post.PostUpdateRequestDto;
+import com.example.demo.model.member.Member;
+import com.example.demo.model.post.Genre;
+import com.example.demo.model.post.Music;
+import com.example.demo.model.post.Post;
+import com.example.demo.repository.MemberRepository;
+import com.example.demo.repository.PostRepository;
+
+@WithMockUser
+@SpringBootTest
+class PostUpdateRemoveTest {
+
+	@Autowired
+	private PostController postController;
+
+	@Autowired
+	private PostRepository postRepository;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	// private ObjectMapper mapper = new ObjectMapper();
+
+	@BeforeEach
+	void setup() {
+		Member member = createMember();
+		memberRepository.save(member);
+		Post post = createPost(
+			member,
+			new Music("1", "url", "singer", "title", Genre.EDM, "url"));
+		postRepository.save(post);
+	}
+
+	@Test
+	@Transactional
+	void 게시글을_수정할_수_있다() {
+		// given
+		String changeContent = "change";
+		Member member = memberRepository.findAll().get(0);
+		Post post = postRepository.findAll().get(0);
+		MemberDetails userDetails = new MemberDetails(member.getId().toString());
+		Principal principal = new TestAuthentication(userDetails);
+		PostUpdateRequestDto requestDto = PostUpdateRequestDto.builder()
+			.content(changeContent)
+			.build();
+
+		// when
+		ResponseEntity<Void> updatePostResponse = postController.updatePost(principal, post.getId(), requestDto);
+		Optional<Post> updatedPost = postRepository.findById(post.getId());
+
+		// then
+		assertThat(updatePostResponse.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+		assertThat(updatedPost).isPresent();
+		assertThat(updatedPost.get().getContent()).isEqualTo(changeContent);
+	}
+}


### PR DESCRIPTION
## PR Description 🗒️
- 게시글 수정 기능 구현

## 추가/변경 사항 및 설명 📝
- PATCH 메소드를 이용하여 구현 -> PUT은 대체의 느낌이라서 수정하기 위한 레코드가 존재하지 않으면 그냥 생성함.
- validation 로직들 추가.
- Rest Docs 테스트 및 통합 테스트 추가.

## Issue close ✂️
#230 
