### PR TITLE
[FIX] Query DSL을 이용한 쿼리 최소화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,14 +18,6 @@ group = 'com.prgrms'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '17'
 
-
-configurations {
-    compileOnly {
-        extendsFrom annotationProcessor
-    }
-    querydsl.extendsFrom compileClasspath
-}
-
 repositories {
     mavenCentral()
 }
@@ -99,12 +91,25 @@ editorconfig {
 }
 //check.dependsOn editorconfigCheck
 
+compileJava.options.encoding = 'UTF-8'
+compileTestJava.options.encoding = 'UTF-8'
+
+tasks.withType(Checkstyle) {
+    reports {
+        xml.required = true
+        html.required = true
+    }
+}
+
 checkstyle {
     maxWarnings = 0
     configFile = file("${rootProject.projectDir}/config/checkstyle/naver-checkstyle-rules.xml")
     configProperties = ["suppressionFile": "${rootProject.projectDir}/config/checkstyle/naver-checkstyle-suppressions.xml"]
     toolVersion = "10.7.0"  // checkstyle
+    sourceSets = [sourceSets.main]
 }
+
+checkstyleMain.source = fileTree('src/main/java')
 
 dependencyManagement {
     imports {
@@ -207,16 +212,21 @@ jacocoTestCoverageVerification {
 }
 
 def querydslDir = "$buildDir/generated/querydsl"
-
 querydsl {
     jpa = true
     querydslSourcesDir = querydslDir
 }
-
 sourceSets {
     main.java.srcDir querydslDir
 }
-
 compileQuerydsl {
     options.annotationProcessorPath = configurations.querydsl
 }
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+    querydsl.extendsFrom compileClasspath
+}
+
+

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ plugins {
     id 'jacoco'
     id 'com.epages.restdocs-api-spec' version '0.16.4'
     id 'org.hidetake.swagger.generator' version '2.19.2'
+    id 'com.ewerk.gradle.plugins.querydsl' version '1.0.10'
 }
 
 jacoco {
@@ -22,6 +23,7 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    querydsl.extendsFrom compileClasspath
 }
 
 repositories {
@@ -73,7 +75,12 @@ dependencies {
     implementation "ca.pjer:logback-awslogs-appender:1.6.0"
     implementation 'com.amazonaws:aws-java-sdk-bom:1.12.417'
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.410'
+
+    implementation 'com.querydsl:querydsl-jpa:5.0.0'
+    implementation 'com.querydsl:querydsl-apt:5.0.0'
+    implementation 'com.querydsl:querydsl-core:5.0.0'
 }
+
 openapi3 {
     server = 'https://localhost:8080'
     title = 'API 명세서'
@@ -197,4 +204,19 @@ jacocoTestCoverageVerification {
 
         }
     }
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+
+sourceSets {
+    main.java.srcDir querydslDir
+}
+
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
 }

--- a/src/main/java/com/example/demo/config/QueryDslConfig.java
+++ b/src/main/java/com/example/demo/config/QueryDslConfig.java
@@ -1,0 +1,21 @@
+package com.example.demo.config;
+
+import javax.persistence.EntityManager;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+@Configuration
+public class QueryDslConfig {
+
+	@Autowired
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/src/main/java/com/example/demo/model/battle/Battle.java
+++ b/src/main/java/com/example/demo/model/battle/Battle.java
@@ -92,8 +92,12 @@ public class Battle extends BaseEntity {
 		battleInfo.plusVoteCount(voteCount);
 	}
 
-	public void quitBattle() {
+	public void endBattle() {
 		this.status = BattleStatus.END;
+	}
+
+	public void quitBattle() {
+		endBattle();
 		updateCountOfWinner();
 	}
 
@@ -107,7 +111,7 @@ public class Battle extends BaseEntity {
 
 	private void updateCountOfWinner() {
 		Optional<Member> winner = getWinner();
-		winner.ifPresent(Member::plusCount);
+		winner.ifPresent(Member::plusVictoryCount);
 	}
 
 	public Optional<Member> getWinner() {
@@ -157,5 +161,4 @@ public class Battle extends BaseEntity {
 		};
 	}
 
-	// TODO: 2023-02-23 battle이 특정 Post를 가지고 있는지 검증하는 메소드
 }

--- a/src/main/java/com/example/demo/model/member/Member.java
+++ b/src/main/java/com/example/demo/model/member/Member.java
@@ -104,8 +104,8 @@ public class Member extends BaseEntity {
 		memberScore.update(ranking, victoryPoint, victoryCount);
 	}
 
-	public void plusCount() {
-		this.memberScore.plusCount();
+	public void plusVictoryCount() {
+		this.memberScore.plusVictoryCount();
 	}
 
 	public void resetRankingAndPoint() {

--- a/src/main/java/com/example/demo/model/member/MemberScore.java
+++ b/src/main/java/com/example/demo/model/member/MemberScore.java
@@ -36,7 +36,7 @@ public class MemberScore {
 		checkArgument(victoryCount >= 0, "승리 횟수가 음수일 수 없습니다.", victoryCount);
 	}
 
-	void plusCount() {
+	void plusVictoryCount() {
 		this.victoryCount += 1;
 	}
 

--- a/src/main/java/com/example/demo/repository/custom/BattleRepositoryCustom.java
+++ b/src/main/java/com/example/demo/repository/custom/BattleRepositoryCustom.java
@@ -1,0 +1,50 @@
+package com.example.demo.repository.custom;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.example.demo.model.battle.Battle;
+import com.example.demo.model.battle.BattleStatus;
+import com.example.demo.model.battle.QBattle;
+import com.example.demo.model.member.QMember;
+import com.example.demo.model.post.QPost;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class BattleRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+	private final QBattle battle = QBattle.battle;
+	private final QPost challengedPost = QPost.post;
+	private final QPost challengingPost = QPost.post;
+	private final QMember challengedMember = QMember.member;
+	private final QMember challengingMember = QMember.member;
+
+	public List<Battle> findByStatusAndCreatedAtIsBefore(BattleStatus status, LocalDateTime now) {
+		return queryFactory
+			.selectFrom(battle)
+			.join(battle.challengedPost.post, challengedPost).fetchJoin()
+			.join(battle.challengingPost.post, challengingPost).fetchJoin()
+			.join(challengedPost.member, challengedMember).fetchJoin()
+			.join(challengingPost.member, challengingMember).fetchJoin()
+			.where(battle.status.eq(status), battle.createdAt.before(now))
+			.fetch();
+	}
+
+	public List<Battle> findByStatusAndUpdatedAtBetween(BattleStatus status, LocalDateTime startDate,
+		LocalDateTime endDate) {
+		return queryFactory
+			.selectFrom(battle)
+			.join(battle.challengedPost.post, challengedPost).fetchJoin()
+			.join(battle.challengingPost.post, challengingPost).fetchJoin()
+			.join(challengedPost.member, challengedMember).fetchJoin()
+			.join(challengingPost.member, challengingMember).fetchJoin()
+			.where(battle.status.eq(status), battle.updatedAt.between(startDate, endDate))
+			.fetch();
+	}
+}

--- a/src/main/java/com/example/demo/service/BattleService.java
+++ b/src/main/java/com/example/demo/service/BattleService.java
@@ -28,6 +28,7 @@ import com.example.demo.model.post.Post;
 import com.example.demo.repository.BattleRepository;
 import com.example.demo.repository.PostRepository;
 import com.example.demo.repository.VoteRepository;
+import com.example.demo.repository.custom.BattleRepositoryCustom;
 
 import lombok.RequiredArgsConstructor;
 
@@ -40,6 +41,7 @@ public class BattleService {
 	private final BattleRepository battleRepository;
 	private final VoteRepository voteRepository;
 	private final PostRepository postRepository;
+	private final BattleRepositoryCustom battleRepositoryCustom;
 
 	@Transactional
 	public Long createBattle(Principal principal, BattleCreateRequestDto battleCreateRequestDto) {
@@ -150,13 +152,13 @@ public class BattleService {
 
 	private List<Battle> findBattleProgress() {
 		LocalDateTime now = LocalDateTime.now();
-		return battleRepository.findByStatusAndCreatedAtIsBefore(BattleStatus.PROGRESS, now);
+		return battleRepositoryCustom.findByStatusAndCreatedAtIsBefore(BattleStatus.PROGRESS, now);
 	}
 
 	private List<Battle> findBattlesEndWithinPerm(int term) {
 		LocalDateTime now = LocalDateTime.now();
 		LocalDateTime lastBattleDay = now.minusDays(term);
-		return battleRepository.findByStatusAndUpdatedAtBetween(BattleStatus.END, lastBattleDay, now);
+		return battleRepositoryCustom.findByStatusAndUpdatedAtBetween(BattleStatus.END, lastBattleDay, now);
 	}
 
 	public BattleDetailsListResponseDto getBattleDetailsListInProgress(Principal principal) {

--- a/src/test/java/com/example/demo/controller/battle/BattleRamdomTest.java
+++ b/src/test/java/com/example/demo/controller/battle/BattleRamdomTest.java
@@ -23,6 +23,7 @@ import com.example.demo.repository.BattleRepository;
 import com.example.demo.repository.MemberRepository;
 import com.example.demo.repository.PostRepository;
 import com.example.demo.repository.VoteRepository;
+import com.example.demo.repository.custom.BattleRepositoryCustom;
 import com.example.demo.service.BattleService;
 import com.example.demo.service.PrincipalService;
 import com.example.demo.service.VoteService;
@@ -45,7 +46,7 @@ class BattleRamdomTest {
 	@BeforeEach
 	void setup() {
 		battleService = new BattleService(mock(PrincipalService.class), battleRepository, mock(VoteRepository.class),
-			postRepository);
+			postRepository, mock(BattleRepositoryCustom.class));
 		battleController = new BattleController(mock(PrincipalService.class), mock(VoteService.class), battleService);
 	}
 

--- a/src/test/java/com/example/demo/model/member/MemberTest.java
+++ b/src/test/java/com/example/demo/model/member/MemberTest.java
@@ -129,7 +129,7 @@ class MemberTest {
 	@Test
 	void 성공_유저의_성공_수를_1만큼_더할_수_있다() {
 		Member member = createMember(profileImageUrl, nickname, refreshToken, socialType, socialId);
-		member.plusCount();
+		member.plusVictoryCount();
 		assertThat(member.getVictoryCount()).isEqualTo(1);
 	}
 

--- a/src/test/java/com/example/demo/repository/custom/BattleRepositoryCustomTest.java
+++ b/src/test/java/com/example/demo/repository/custom/BattleRepositoryCustomTest.java
@@ -1,0 +1,110 @@
+package com.example.demo.repository.custom;
+
+import static com.example.demo.controller.TestUtil.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.example.demo.config.JpaAuditingConfig;
+import com.example.demo.config.QueryDslConfig;
+import com.example.demo.model.battle.Battle;
+import com.example.demo.model.battle.BattleStatus;
+import com.example.demo.model.member.Member;
+import com.example.demo.model.post.Genre;
+import com.example.demo.model.post.Music;
+import com.example.demo.model.post.Post;
+import com.example.demo.repository.BattleRepository;
+import com.example.demo.repository.MemberRepository;
+import com.example.demo.repository.PostRepository;
+
+@DataJpaTest
+@Import({QueryDslConfig.class, BattleRepositoryCustom.class, JpaAuditingConfig.class})
+class BattleRepositoryCustomTest {
+
+	private static final int BATTLE_CNT = 10;
+	@Autowired
+	BattleRepository battleRepository;
+
+	@Autowired
+	MemberRepository memberRepository;
+
+	@Autowired
+	PostRepository postRepository;
+
+	@Autowired
+	BattleRepositoryCustom battleRepositoryCustom;
+
+	@BeforeEach
+	void setup() {
+		IntStream.rangeClosed(1, BATTLE_CNT)
+			.forEach(i -> {
+				Member member1 = createMember(String.valueOf(i));
+				Member member2 = createMember(String.valueOf(i * BATTLE_CNT + i));
+				memberRepository.save(member1);
+				memberRepository.save(member2);
+
+				Post challengedPost = createPost(member1,
+					createMusic(String.valueOf(i)));
+				Post challengingPost = createPost(member2,
+					createMusic(String.valueOf(i * BATTLE_CNT + i)));
+				postRepository.save(challengedPost);
+				postRepository.save(challengingPost);
+
+				battleRepository.save(createBattle(challengedPost, challengingPost));
+			});
+	}
+
+	@Test
+	void QueryDsl을_이용하여_특정_시점보다_이전에_생성된_진행중인_대결을_가져올_수_있다() {
+		List<Battle> progressBattles = battleRepositoryCustom
+			.findByStatusAndCreatedAtIsBefore(BattleStatus.PROGRESS, LocalDateTime.now().plusDays(1));
+		assertThat(progressBattles.size()).isEqualTo(BATTLE_CNT);
+		progressBattles
+			.forEach(battle ->
+				assertThat(battle.getStatus()).isEqualTo(BattleStatus.PROGRESS)
+			);
+	}
+
+	@Test
+	void QueryDsl을_이용하여_특정_시점_사이에_수정되고_끝난_대결을_가져올_수_있다() {
+		modifyBattle();
+		List<Battle> progressBattles = battleRepositoryCustom
+			.findByStatusAndUpdatedAtBetween(BattleStatus.END, LocalDateTime.now(), LocalDateTime.now().plusDays(1));
+		assertThat(progressBattles.size()).isEqualTo(BATTLE_CNT);
+		progressBattles
+			.forEach(battle ->
+				assertThat(battle.getStatus()).isEqualTo(BattleStatus.END)
+			);
+	}
+
+	private void modifyBattle() {
+		List<Battle> allBattles = battleRepository.findAll();
+		allBattles.forEach(Battle::endBattle);
+	}
+
+	private Battle createBattle(Post challengedPost, Post challengingPost) {
+		return new Battle(
+			challengedPost.getMusic().getGenre(),
+			BattleStatus.PROGRESS,
+			challengedPost,
+			challengingPost
+		);
+	}
+
+	private Music createMusic(String id) {
+		return new Music(id,
+			"aUrl",
+			"s",
+			"t",
+			Genre.BALLAD,
+			"mUrl");
+	}
+}

--- a/src/test/java/com/example/demo/service/BattleServiceTest.java
+++ b/src/test/java/com/example/demo/service/BattleServiceTest.java
@@ -19,6 +19,7 @@ import com.example.demo.model.member.Social;
 import com.example.demo.model.post.Genre;
 import com.example.demo.model.post.Post;
 import com.example.demo.repository.BattleRepository;
+import com.example.demo.repository.custom.BattleRepositoryCustom;
 
 @ExtendWith(MockitoExtension.class)
 class BattleServiceTest {
@@ -27,6 +28,9 @@ class BattleServiceTest {
 	private BattleService battleService;
 	@Mock
 	private BattleRepository battleRepository;
+
+	@Mock
+	private BattleRepositoryCustom battleRepositoryCustom;
 
 	private final Genre genre = Genre.K_POP;
 	private final BattleStatus progressStatus = BattleStatus.PROGRESS;
@@ -39,7 +43,7 @@ class BattleServiceTest {
 		List<Battle> battles = getBattles();
 
 		// when
-		when(battleRepository.findByStatusAndCreatedAtIsBefore(any(), any())).thenReturn(battles);
+		when(battleRepositoryCustom.findByStatusAndCreatedAtIsBefore(any(), any())).thenReturn(battles);
 
 		battleService.quitBattles();
 
@@ -48,7 +52,7 @@ class BattleServiceTest {
 			assertThat(battle.getStatus()).isEqualTo(BattleStatus.END);
 		}
 
-		verify(battleRepository).findByStatusAndCreatedAtIsBefore(any(), any());
+		verify(battleRepositoryCustom).findByStatusAndCreatedAtIsBefore(any(), any());
 	}
 
 	@Test
@@ -60,7 +64,7 @@ class BattleServiceTest {
 		}
 
 		// when
-		when(battleRepository.findByStatusAndUpdatedAtBetween(any(), any(), any())).thenReturn(battles);
+		when(battleRepositoryCustom.findByStatusAndUpdatedAtBetween(any(), any(), any())).thenReturn(battles);
 
 		battleService.updateWinnerPoint(7);
 
@@ -70,7 +74,7 @@ class BattleServiceTest {
 				.isEqualTo(10 * battles.size());
 		}
 
-		verify(battleRepository).findByStatusAndUpdatedAtBetween(any(), any(), any());
+		verify(battleRepositoryCustom).findByStatusAndUpdatedAtBetween(any(), any(), any());
 	}
 
 	private List<Battle> getBattles() {


### PR DESCRIPTION
## PR Description 🗒️

## 추가/변경 사항 및 설명 📝
- Query DSL을 이용하여 fetch join을 통해서 로직 상 무조건 사용되는 Post 정보와 Member 정보를 먼저 가져와 쿼리의 수를 줄임.
- 대결 10개 기준으로 쿼리 최소화 전 - 2170ms 소요
![이전 배치](https://user-images.githubusercontent.com/78334910/231331463-c10fee5f-9f3b-4c7a-9ec0-79770fb9b132.png)
